### PR TITLE
Fix babel not transpiling our files

### DIFF
--- a/rollup.shared.js
+++ b/rollup.shared.js
@@ -6,7 +6,6 @@ const commonjs = require('@rollup/plugin-commonjs');
 
 module.exports.babelPlugin = babel({ 
   babelHelpers: 'runtime',
-  include: /node_modules/,
 });
 
 module.exports.nodeResolvePlugin = nodeResolve({


### PR DESCRIPTION
Noticed while manually testing in IE that there was an odd syntax error from for ... of statements instead of the error from `throwIfUnsupportedBrowser.js` as expected. Then noticed that only our files (everything in `src/` folders) weren't being touched by babel and were in their raw form in built files (class syntax and all). Removing the filter so absolutely all files get babel treatment