### PR TITLE
Wrap event listeners on document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - New configuration option cookieDomain. This can be used to manually set session cookie domain.
+- Wrap event listeners on document
 
 ## 0.3.1
 - New meta version `latest` is now available from CDN, it is always updated, even if there are changes, which are not backwards-compatible

--- a/integration-tests/tests/user-interaction/mouse-document.ejs
+++ b/integration-tests/tests/user-interaction/mouse-document.ejs
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Event target</title>
+  <%- renderAgent() %>
+  
+</head>
+<body>
+  <h1>Document target</h1>
+
+  <button type="button" id="btn1">Button</button>
+
+  <pre id="scenarioDisplay"></pre>
+  <script id="scenario">
+    document.addEventListener('click', function () {});
+  </script>
+  <script>scenarioDisplay.innerHTML = scenario.innerHTML;</script>
+</body>
+</html>

--- a/integration-tests/tests/user-interaction/mouse.spec.js
+++ b/integration-tests/tests/user-interaction/mouse.spec.js
@@ -81,4 +81,20 @@ module.exports = {
       'Ensuring no click span arrived.'
     );
   },
+  'handles clicks with event listener on document': async function (browser) {
+    browser.globals.clearReceivedSpans();
+    await browser.url(browser.globals.getUrl('/user-interaction/mouse-document.ejs'));
+    await browser.click('#btn1');
+
+    const clickSpan = await browser.globals.findSpan(span => span.name === 'click');
+    await browser.assert.ok(!!clickSpan, 'Checking click span presence.');
+
+    await browser.assert.strictEqual(clickSpan.tags['component'], 'user-interaction');
+    await browser.assert.strictEqual(clickSpan.tags['event_type'], 'click');
+    await browser.assert.strictEqual(clickSpan.tags['target_element'], 'HTML');
+    await browser.assert.strictEqual(clickSpan.tags['target_xpath'], '//html');
+    await browser.assert.strictEqual(clickSpan.tags['ot.status_code'], 'UNSET');
+
+    await browser.globals.assertNoErrorSpans();
+  }
 };

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { trace } from '@opentelemetry/api';
+import {diag, trace} from '@opentelemetry/api';
+import {isWrapped} from '@opentelemetry/instrumentation';
 import {UserInteractionInstrumentation} from '@opentelemetry/instrumentation-user-interaction';
 
 export const DEFAULT_AUTO_INSTRUMENTED_EVENTS = {
@@ -66,6 +67,15 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
     return !!this._autoInstrumentedEvents[eventType];
   }
 
+  _createSpan(element, eventName, parentSpan) {
+    // Fix: No span is created when event is captured from document
+    if (element === document) {
+      element = document.documentElement;
+    }
+
+    return super._createSpan(element, eventName, parentSpan);
+  }
+
   emitRouteChangeSpan(oldHref) {
     const span = this._routingTracer.startSpan('routeChange');
     span.setAttribute('component', this.moduleName);
@@ -82,8 +92,27 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
     // Hash can be changed with location.hash = '#newThing', no way to hook that directly...
     window.addEventListener('hashchange', this.__hashChangeHandler);
 
-    // parent wraps calls to addEventListener so call after us
-    super.enable();
+    // Current parent implementation patches HTMLElement's prototype, which causes it to miss document.addEvenetListener:
+    // HTMLElementPrototype -> ElementPrototype -> NodePrototype -> EventTargetPrototype -> Object
+    // HTMLDocumentPrototype -> DocumentPrototype -> NodePrototype -> EventTargetPrototype -> Object
+    // Most browsers have addEventListener on EventTargetPrototype, except for IE for which it doesn't exist and uses NodePrototype
+    if (this.getZoneWithPrototype()) {
+      super.enable();
+    } else {
+      this._zonePatched = false;
+      if (isWrapped(Node.prototype.addEventListener)) {
+        this._unwrap(Node.prototype, 'addEventListener');
+        diag.debug('removing previous patch from method addEventListener');
+      }
+      if (isWrapped(Node.prototype.removeEventListener)) {
+        this._unwrap(Node.prototype, 'removeEventListener');
+        diag.debug('removing previous patch from method removeEventListener');
+      }
+      this._wrap(Node.prototype, 'addEventListener', this._patchElement());
+      this._wrap(Node.prototype, 'removeEventListener', this._patchRemoveEventListener());
+
+      this._patchHistoryApi();
+    }
   }
 
   disable() {

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -117,7 +117,18 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
 
   disable() {
     // parent unwraps calls to addEventListener so call before us
-    super.disable();
+    if (this._zonePatched) {
+      super.disable();
+    } else {
+      if (isWrapped(Node.prototype.addEventListener)) {
+        this._unwrap(Node.prototype, 'addEventListener');
+      }
+      if (isWrapped(Node.prototype.removeEventListener)) {
+        this._unwrap(Node.prototype, 'removeEventListener');
+      }
+      this._unpatchHistoryApi();
+    }
+
     window.removeEventListener('hashchange', this.__hashChangeHandler);
   }
 


### PR DESCRIPTION
Currently event listeners on document don't get wrapped like on elements, which makes a difference in react <= 16 where listeners regardless of element are registered on document (and then react does it's own bubbling). These will have less information on event target element (as the element is captured from which element was listening, and it's kinda impossible to guess intent)

EventTarget is more generic than the user interaction targets this instrumentation cares about and doesn't exist in IE11, so targeting the most common prototype for elements & document.

APMI-1416