### PR TITLE
Fix package name in npm examples

### DIFF
--- a/examples/installing-npm/README.md
+++ b/examples/installing-npm/README.md
@@ -23,7 +23,7 @@ Navigate to <https://app.signalfx.com/o11y/> to see your data.
 ## Installing via NPM in your own app
 
 ```bash
-npm install @splunk/splunk-otel-web
+npm install @splunk/otel-web
 ```
 Note: in modern versions of NPM, installed packages are added to `package.json` by default.
 


### PR DESCRIPTION
Update @splunk/splunk-otel-web to @splunk/otel-web npm examples.