### PR TITLE
WebSocket instrumentation: Add extra test to check for static props

### DIFF
--- a/test/websockets.test.ts
+++ b/test/websockets.test.ts
@@ -134,4 +134,10 @@ describe('can produce websocket events', () => {
       assert.strictEqual(true, capturer.spans[0].attributes.error);
     }
   });
+  it ('Websocket keeps static values', () => {
+    assert.strictEqual(WebSocket.CONNECTING, 0);
+    assert.strictEqual(WebSocket.OPEN, 1);
+    assert.strictEqual(WebSocket.CLOSING, 2);
+    assert.strictEqual(WebSocket.CLOSED, 3);
+  })
 });

--- a/test/websockets.test.ts
+++ b/test/websockets.test.ts
@@ -139,5 +139,5 @@ describe('can produce websocket events', () => {
     assert.strictEqual(WebSocket.OPEN, 1);
     assert.strictEqual(WebSocket.CLOSING, 2);
     assert.strictEqual(WebSocket.CLOSED, 3);
-  })
+  });
 });


### PR DESCRIPTION
Original issue (APMI-1375) was that `reconnecting-websocket` couldn't use instrumented WebSocket because [`WebSocket.CLOSING` value was missing](https://github.com/pladaria/reconnecting-websocket/blob/05a2f7cb0e31f15dff5ff35ad53d07b1bec5e197/reconnecting-websocket.ts#L20). Typescript conversion [changed instrumenting from function to class extends](https://github.com/signalfx/splunk-otel-js-web/pull/143/files#diff-845430eee1ed1832871e1940f0cdf91ff03823313ba893e20e99ab82cb665237R49) and that pretty much fixed the issue. Adding an extra test to make sure it will stay that way.