### PR TITLE
Update documentation for manual instrumentation

### DIFF
--- a/docs/ManualInstrumentation.md
+++ b/docs/ManualInstrumentation.md
@@ -1,10 +1,12 @@
 # Manual instrumentation using API
 
-In case when auto-instrumentations do not capture all the information needed, you can capture additional telemetry by manually instrumenting your application (for example, to report timings for keyboard events), you can use the [OpenTelemetry API](https://github.com/open-telemetry/opentelemetry-js/tree/master/packages/opentelemetry-tracing). The `TracingProvider` used by Splunk Browser Agent in `SplunkRum.provider`.
+In case when auto-instrumentations do not capture all the information needed, you can capture additional telemetry by manually instrumenting your application (for example, to report timings for actions that take multiple requests), you can use the [OpenTelemetry API](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-tracing). Splunk Browser Agent automatically registers it's TraceProvider with `@opentelemetry/api`, allowing you or any other instrumentations you want to use to access it via standard methods.
+
+> The version of `@opentelemetry/api` should match [the agent's used `@opentelemetry/api` version](https://github.com/signalfx/splunk-otel-js-web#open-telemetry-version) <!-- TODO when stable it may be of same major and up to same minor version -->
 
 |Example|Instrumentation code|
 |---|---|
-|Manually creating a span:|<pre>const provider = SplunkRum.provider;<br>const span = provider.getTracer('searchbox').startSpan('search');<br>span.setAttribute('searchLength', searchString.length);<br>// time passes<br>span.end();</pre>|
+|Manually creating a span:|<pre>import {trace} from '@opentelemetry/api'<br><br>const span = trace.getTracer('searchbox').startSpan('search');<br>span.setAttribute('searchLength', searchString.length);<br>// time passes<br>span.end();</pre>|
 |Set `userId` on all the spans:|<pre>SplunkRum.setGlobalAttributes({<br>  'user': 'Test User'<br>});</pre>|
 
 If you have some existing manual instrumentation of your app with, e.g., another vendor's API, you can usually translate this code fairly easily to use OpenTelemetry conventions. We have provided [a migration guide](https://github.com/signalfx/splunk-otel-js-web/blob/main/docs/MigratingInstrumentation.md) covering this in more in depth.

--- a/docs/MigratingInstrumentation.md
+++ b/docs/MigratingInstrumentation.md
@@ -13,8 +13,10 @@ users.  OpenTelemetry represents operations like this with spans; in addition to
 and end time, you can also include additional details in key-value pairs called attributes:
 
 ```javascript
+import {trace} from '@opentelemetry/api'
+
 function calculateEstateTax(estate) {
-    const span = SplunkRum.provider.getTracer('estate').startSpan('calculateEstateTax');
+    const span = trace.getTracer('estate').startSpan('calculateEstateTax');
     span.setAttribute('estate.jurisdictionCount', estate.jurisdictions.length);
     var taxOwed = 0;
     // ...


### PR DESCRIPTION
Recommend using `@opentelemetry/api` for manually instrumenting for better interoperability and avoiding confusion about having to pass SplunkRUM around when dealing with multiple applications on the same page 