### PR TITLE
Fix CDN invalidation path

### DIFF
--- a/scripts/release-cdn.mjs
+++ b/scripts/release-cdn.mjs
@@ -123,7 +123,7 @@ if (!isDryRun) {
     InvalidationBatch: {
       CallerReference: invalidationRef,
       Paths: {
-        Items: ['/cdn/o11y-gdi-rum/*'],
+        Items: ['/o11y-gdi-rum/*'],
         Quantity: 1,
       },
     },


### PR DESCRIPTION
As pointed out by tests invalidation isn't quite working and some are returning 0.5.0 instead of 0.5.1