### PR TITLE
what if: tests that use waitForTestToFinish don't have a lowered bufferTimeout

### DIFF
--- a/integration-tests/tests/context/async-context.spec.js
+++ b/integration-tests/tests/context/async-context.spec.js
@@ -31,7 +31,6 @@ async function runTest(browser, filename, extraChecks) {
   const childSpan = await browser.globals.findSpan(span => span.name === 'context-child');
 
   browser.assert.not.ok(clickSpan.parentId, 'Click span does not have a parent.');
-  console.log(childSpan);
   browser.assert.strictEqual(childSpan.parentId, clickSpan.id, 'Child span belongs to user interaction trace.');
 
   await browser.globals.assertNoErrorSpans();

--- a/integration-tests/tests/context/fetch-then.ejs
+++ b/integration-tests/tests/context/fetch-then.ejs
@@ -5,6 +5,7 @@
   <title>Fetch - then</title>
 
   <%- renderAgent({
+    bufferTimeout: 5000,
     context: {
       async: true
     }
@@ -17,8 +18,10 @@
 
   <script>
     btn1.addEventListener('click', function () {
+      window.testing = true
       fetch('/some-data').then(response => response.json()).then(res => {
         SplunkRum.provider.getTracer('default').startSpan('context-child').end();
+        window.testing = false;
       });
     });
   </script>

--- a/integration-tests/tests/context/messageport-addeventlistener.ejs
+++ b/integration-tests/tests/context/messageport-addeventlistener.ejs
@@ -5,6 +5,7 @@
   <title>MessagePort - addEventListener</title>
 
   <%- renderAgent({
+    bufferTimeout: 5000,
     context: {
       async: true
     }

--- a/integration-tests/tests/context/messageport-cors.ejs
+++ b/integration-tests/tests/context/messageport-cors.ejs
@@ -5,6 +5,7 @@
   <title>MessagePort Iframe</title>
 
   <%- renderAgent({
+    bufferTimeout: 5000,
     context: {
       async: true
     }

--- a/integration-tests/tests/context/messageport-onmessage.ejs
+++ b/integration-tests/tests/context/messageport-onmessage.ejs
@@ -5,6 +5,7 @@
   <title>MessagePort - onmessage</title>
 
   <%- renderAgent({
+    bufferTimeout: 5000,
     context: {
       async: true
     }

--- a/integration-tests/tests/context/mutation-observer-textnode.ejs
+++ b/integration-tests/tests/context/mutation-observer-textnode.ejs
@@ -5,6 +5,7 @@
   <title>Mutation Observer - textNode</title>
 
   <%- renderAgent({
+    bufferTimeout: 5000,
     context: {
       async: true
     }

--- a/integration-tests/tests/context/promise.ejs
+++ b/integration-tests/tests/context/promise.ejs
@@ -5,6 +5,7 @@
   <title>Promise</title>
 
   <%- renderAgent({
+    bufferTimeout: 5000,
     context: {
       async: true
     }

--- a/integration-tests/tests/context/set-immediate.ejs
+++ b/integration-tests/tests/context/set-immediate.ejs
@@ -5,6 +5,7 @@
   <title>setImmediate</title>
 
   <%- renderAgent({
+    bufferTimeout: 5000,
     context: {
       async: true
     }

--- a/integration-tests/tests/context/set-timeout.ejs
+++ b/integration-tests/tests/context/set-timeout.ejs
@@ -5,6 +5,7 @@
   <title>setTimeout</title>
 
   <%- renderAgent({
+    bufferTimeout: 5000,
     context: {
       async: true
     }

--- a/integration-tests/tests/context/xhr-events-removed.ejs
+++ b/integration-tests/tests/context/xhr-events-removed.ejs
@@ -5,6 +5,7 @@
   <title>XHR - events</title>
 
   <%- renderAgent({
+    bufferTimeout: 5000,
     context: {
       async: true
     }

--- a/integration-tests/tests/context/xhr-events.ejs
+++ b/integration-tests/tests/context/xhr-events.ejs
@@ -5,6 +5,7 @@
   <title>XHR - events</title>
 
   <%- renderAgent({
+    bufferTimeout: 5000,
     context: {
       async: true
     }

--- a/integration-tests/tests/context/xhr-onload.ejs
+++ b/integration-tests/tests/context/xhr-onload.ejs
@@ -5,6 +5,7 @@
   <title>XHR - events</title>
 
   <%- renderAgent({
+    bufferTimeout: 5000,
     context: {
       async: true
     }

--- a/integration-tests/tests/xhr/views/xhr-basic.ejs
+++ b/integration-tests/tests/xhr/views/xhr-basic.ejs
@@ -4,7 +4,9 @@
   <meta charset="UTF-8">
   <title>XHR</title>
 
-  <%- renderAgent() %>
+  <%- renderAgent({
+    bufferTimeout: 5000,
+  }) %>
 </head>
 <body>
   <h1>XHR</h1>
@@ -25,7 +27,7 @@
       // testing done to be after that.
       setTimeout(function () {
         window.testing = false;
-      }, 301);
+      }, 400);
     })
   </script>
   </body>

--- a/integration-tests/tests/xhr/xhr-basic.spec.js
+++ b/integration-tests/tests/xhr/xhr-basic.spec.js
@@ -23,6 +23,8 @@ module.exports = {
   },
   'XHR request is registered': async function(browser) {
     await browser.url(browser.globals.getUrl('/xhr/views/xhr-basic.ejs'));
+    await browser.globals.waitForTestToFinish();
+
     const xhrSpan = await browser.globals.findSpan(span => span.tags['http.url'] === '/some-data');
     await browser.assert.ok(xhrSpan, 'got an xhr span');
     await browser.assert.strictEqual(xhrSpan.tags['component'], 'xml-http-request');


### PR DESCRIPTION
draft pr to run github actions

Theory: Selenium tunnel sends data back and forth faster than span data arrives over http. By disabling the lowered 20ms buffer it is more likely that we can track when batches arrive.