### PR TITLE
Capture visibility events

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -112,7 +112,7 @@ module.exports = {
         '@typescript-eslint/no-unused-vars': 'error',
 
         // temporarily disabled rules, as we transition to Typescript
-        '@typescript-eslint/no-empty-function': 'warn',
+        '@typescript-eslint/no-empty-function': 'off',
         '@typescript-eslint/no-this-alias': 'warn',
         '@typescript-eslint/explicit-module-boundary-types': ['error', {
           allowArgumentsExplicitlyTypedAsAny: true, // temporarily till code is completely migrated

--- a/integration-tests/tests/visibility/visibility.ejs
+++ b/integration-tests/tests/visibility/visibility.ejs
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Test visibility</title>
+
+	<%- renderAgent({debug: true}) %>
+</head>
+<body>
+    <h1>visibility</h1>    
+</body>
+</html>

--- a/integration-tests/tests/visibility/visibility.ejs
+++ b/integration-tests/tests/visibility/visibility.ejs
@@ -4,7 +4,7 @@
 	<meta charset="UTF-8">
 	<title>Test visibility</title>
 
-	<%- renderAgent({debug: true}) %>
+	<%- renderAgent({debug: true, instrumentations: {visibility: true}}) %>
 </head>
 <body>
     <h1>visibility</h1>    

--- a/integration-tests/tests/visibility/visibility.spec.js
+++ b/integration-tests/tests/visibility/visibility.spec.js
@@ -1,0 +1,38 @@
+/*
+Copyright 2021 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module.exports = {
+    'visibility events are captured': async function(browser) {
+      await browser.url(browser.globals.getUrl('/visibility/visibility.ejs'));
+      browser.globals.emulateTabSwitching(true);
+
+      const tabHiddenSpan = await browser.globals.findSpan(span => span.name === 'visibility' && span.tags['hidden'] === 'true');
+      const hiddenSpans = browser.globals.getReceivedSpans().filter( span => span.name === 'visibility');    
+      await browser.assert.ok(!!tabHiddenSpan, 'Visibility event for hidden tab exists');     
+      await browser.assert.strictEqual(hiddenSpans.length, 1, 'There is only one visibility event');    
+      
+      browser.globals.clearReceivedSpans();    
+
+      browser.globals.emulateTabSwitching(false);
+      const tabVisibileSpan = await browser.globals.findSpan(span => span.name === 'visibility' && span.tags['hidden'] === 'false');
+      const visibleSpans = browser.globals.getReceivedSpans().filter( span => span.name === 'visibility');      
+      await browser.assert.ok(!!tabVisibileSpan, 'Visibility event for visible tab exists');      
+      await browser.assert.strictEqual(visibleSpans.length, 1, 'There is only one visibility event');    
+
+      await browser.globals.assertNoErrorSpans();
+    },
+  };
+  

--- a/integration-tests/tests/visibility/visibility.spec.js
+++ b/integration-tests/tests/visibility/visibility.spec.js
@@ -15,24 +15,24 @@ limitations under the License.
 */
 
 module.exports = {
-    'visibility events are captured': async function(browser) {
-      await browser.url(browser.globals.getUrl('/visibility/visibility.ejs'));
-      browser.globals.emulateTabSwitching(true);
+  'visibility events are captured': async function(browser) {
+    await browser.url(browser.globals.getUrl('/visibility/visibility.ejs'));
+    browser.globals.emulateTabSwitching(true);
 
-      const tabHiddenSpan = await browser.globals.findSpan(span => span.name === 'visibility' && span.tags['hidden'] === 'true');
-      const hiddenSpans = browser.globals.getReceivedSpans().filter( span => span.name === 'visibility');    
-      await browser.assert.ok(!!tabHiddenSpan, 'Visibility event for hidden tab exists');     
-      await browser.assert.strictEqual(hiddenSpans.length, 1, 'There is only one visibility event');    
+    const tabHiddenSpan = await browser.globals.findSpan(span => span.name === 'visibility' && span.tags['hidden'] === 'true');
+    const hiddenSpans = browser.globals.getReceivedSpans().filter( span => span.name === 'visibility');    
+    await browser.assert.ok(!!tabHiddenSpan, 'Visibility event for hidden tab exists');     
+    await browser.assert.strictEqual(hiddenSpans.length, 1, 'There is only one visibility event');    
       
-      browser.globals.clearReceivedSpans();    
+    browser.globals.clearReceivedSpans();    
 
-      browser.globals.emulateTabSwitching(false);
-      const tabVisibileSpan = await browser.globals.findSpan(span => span.name === 'visibility' && span.tags['hidden'] === 'false');
-      const visibleSpans = browser.globals.getReceivedSpans().filter( span => span.name === 'visibility');      
-      await browser.assert.ok(!!tabVisibileSpan, 'Visibility event for visible tab exists');      
-      await browser.assert.strictEqual(visibleSpans.length, 1, 'There is only one visibility event');    
+    browser.globals.emulateTabSwitching(false);
+    const tabVisibileSpan = await browser.globals.findSpan(span => span.name === 'visibility' && span.tags['hidden'] === 'false');
+    const visibleSpans = browser.globals.getReceivedSpans().filter( span => span.name === 'visibility');      
+    await browser.assert.ok(!!tabVisibileSpan, 'Visibility event for visible tab exists');      
+    await browser.assert.strictEqual(visibleSpans.length, 1, 'There is only one visibility event');    
 
-      await browser.globals.assertNoErrorSpans();
-    },
-  };
+    await browser.globals.assertNoErrorSpans();
+  },
+};
   

--- a/integration-tests/utils/globals.js
+++ b/integration-tests/utils/globals.js
@@ -73,11 +73,12 @@ module.exports = {
     browser.globals.getLastServerTiming = backend.getLastServerTiming;
     browser.globals.getUrl = (...args) => backend.getUrl(...args).toString();
 
-    browser.globals.emulateTabSwitchingAway = async () => {
-      await browser.execute(() => {
-        Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
-        document.dispatchEvent(new Event('visibilitychange'));
-      });
+    browser.globals.emulateTabSwitching = async (visible) => {
+      await browser.execute((hidden) => {
+        Object.defineProperty(document, 'hidden', { value: hidden, configurable: true });
+        Object.defineProperty(document,'visibilityState', { value: hidden ? 'hidden': 'visible', configurable: true });
+        window.dispatchEvent(new Event('visibilitychange'));
+      }, [visible]);
     };
 
     browser.globals.waitForTestToFinish = async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "browserstack-local": "^1.4.8",
         "chai": "^4.3.4",
         "chrome-launcher": "^0.14.0",
-        "chromedriver": "^92.0.0",
+        "chromedriver": "^91.0.0",
         "codecov": "^3.8.2",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
@@ -4818,9 +4818,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "92.0.0",
-      "resolved": "https://repo.splunkdev.net:443/artifactory/api/npm/npm/chromedriver/-/chromedriver-92.0.0.tgz",
-      "integrity": "sha1-eGDv59CC7Id9yBRqqSDTA0D8u0c=",
+      "version": "91.0.1",
+      "resolved": "https://repo.splunkdev.net:443/artifactory/api/npm/npm/chromedriver/-/chromedriver-91.0.1.tgz",
+      "integrity": "sha1-TXClaZAeNWyXikHeMBnEZPKo69A=",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -17848,9 +17848,9 @@
       }
     },
     "chromedriver": {
-      "version": "92.0.0",
-      "resolved": "https://repo.splunkdev.net:443/artifactory/api/npm/npm/chromedriver/-/chromedriver-92.0.0.tgz",
-      "integrity": "sha1-eGDv59CC7Id9yBRqqSDTA0D8u0c=",
+      "version": "91.0.1",
+      "resolved": "https://repo.splunkdev.net:443/artifactory/api/npm/npm/chromedriver/-/chromedriver-91.0.1.tgz",
+      "integrity": "sha1-TXClaZAeNWyXikHeMBnEZPKo69A=",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "browserstack-local": "^1.4.8",
         "chai": "^4.3.4",
         "chrome-launcher": "^0.14.0",
-        "chromedriver": "^91.0.1",
+        "chromedriver": "^92.0.0",
         "codecov": "^3.8.2",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
@@ -4818,11 +4818,12 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "91.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-91.0.1.tgz",
-      "integrity": "sha512-9LktpHiUxM4UWUsr+jI1K1YKx2GENt6BKKJ2mibPj1Wc6ODzX/3fFIlr8CZ4Ftuyga+dHTTbAyPWKwKvybEbKA==",
+      "version": "92.0.0",
+      "resolved": "https://repo.splunkdev.net:443/artifactory/api/npm/npm/chromedriver/-/chromedriver-92.0.0.tgz",
+      "integrity": "sha1-eGDv59CC7Id9yBRqqSDTA0D8u0c=",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@testim/chrome-version": "^1.0.7",
         "axios": "^0.21.1",
@@ -17847,9 +17848,9 @@
       }
     },
     "chromedriver": {
-      "version": "91.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-91.0.1.tgz",
-      "integrity": "sha512-9LktpHiUxM4UWUsr+jI1K1YKx2GENt6BKKJ2mibPj1Wc6ODzX/3fFIlr8CZ4Ftuyga+dHTTbAyPWKwKvybEbKA==",
+      "version": "92.0.0",
+      "resolved": "https://repo.splunkdev.net:443/artifactory/api/npm/npm/chromedriver/-/chromedriver-92.0.0.tgz",
+      "integrity": "sha1-eGDv59CC7Id9yBRqqSDTA0D8u0c=",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "browserstack-local": "^1.4.8",
     "chai": "^4.3.4",
     "chrome-launcher": "^0.14.0",
-    "chromedriver": "^91.0.1",
+    "chromedriver": "^92.0.0",
     "codecov": "^3.8.2",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "browserstack-local": "^1.4.8",
     "chai": "^4.3.4",
     "chrome-launcher": "^0.14.0",
-    "chromedriver": "^92.0.0",
+    "chromedriver": "^91.0.0",
     "codecov": "^3.8.2",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/src/SplunkLongTaskInstrumentation.ts
+++ b/src/SplunkLongTaskInstrumentation.ts
@@ -29,7 +29,6 @@ export class SplunkLongTaskInstrumentation extends InstrumentationBase {
     super(MODULE_NAME, VERSION, Object.assign({}, config));
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   init(): void {}
 
   enable(): void {

--- a/src/SplunkPageVisibilityInstrumentation.ts
+++ b/src/SplunkPageVisibilityInstrumentation.ts
@@ -35,24 +35,24 @@ export class SplunkPageVisibilityInstrumentation extends InstrumentationBase {
 
   enable(): void {
     if (document.hidden) {
-        this._createSpan(document.hidden);
+      this._createSpan(document.hidden);
     }
 
     visibilityListener = window.addEventListener('beforeunload', () => {
-        this.unloading = true;
-    })
+      this.unloading = true;
+    });
 
     visibilityListener = window.addEventListener('visibilitychange', () => {
-        //ignore when page is unloading as it is expected then
-        if (!this.unloading) {
-            this._createSpan(document.hidden);
-        }
-    })
+      //ignore when page is unloading as it is expected then
+      if (!this.unloading) {
+        this._createSpan(document.hidden);
+      }
+    });
   }
 
   disable(): void {
-      window.removeEventListener('beforeunload', unloadListener);
-      window.removeEventListener('visibilitychange', visibilityListener);
+    window.removeEventListener('beforeunload', unloadListener);
+    window.removeEventListener('visibilitychange', visibilityListener);
   }
 
   private _createSpan(hidden: boolean) {

--- a/src/SplunkPageVisibilityInstrumentation.ts
+++ b/src/SplunkPageVisibilityInstrumentation.ts
@@ -19,18 +19,17 @@ import { InstrumentationBase, InstrumentationConfig } from '@opentelemetry/instr
 import { VERSION } from './version';
 
 const MODULE_NAME = 'splunk-visibility';
-let visibilityListener: any;
-let unloadListener: any;
 
 export class SplunkPageVisibilityInstrumentation extends InstrumentationBase {
   unloading: boolean;
+  visibilityListener: any;
+  unloadListener: any;
 
   constructor(config: InstrumentationConfig = {}) {
     super(MODULE_NAME, VERSION, Object.assign({}, config));
     this.unloading = false;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   init(): void {}
 
   enable(): void {
@@ -38,11 +37,11 @@ export class SplunkPageVisibilityInstrumentation extends InstrumentationBase {
       this._createSpan(document.hidden);
     }
 
-    visibilityListener = window.addEventListener('beforeunload', () => {
+    this.visibilityListener = window.addEventListener('beforeunload', () => {
       this.unloading = true;
     });
 
-    visibilityListener = window.addEventListener('visibilitychange', () => {
+    this.visibilityListener = window.addEventListener('visibilitychange', () => {
       //ignore when page is unloading as it is expected then
       if (!this.unloading) {
         this._createSpan(document.hidden);
@@ -51,8 +50,8 @@ export class SplunkPageVisibilityInstrumentation extends InstrumentationBase {
   }
 
   disable(): void {
-    window.removeEventListener('beforeunload', unloadListener);
-    window.removeEventListener('visibilitychange', visibilityListener);
+    window.removeEventListener('beforeunload', this.unloadListener);
+    window.removeEventListener('visibilitychange', this.visibilityListener);
   }
 
   private _createSpan(hidden: boolean) {

--- a/src/SplunkPageVisibilityInstrumentation.ts
+++ b/src/SplunkPageVisibilityInstrumentation.ts
@@ -1,0 +1,56 @@
+/*
+Copyright 2021 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { hrTime } from '@opentelemetry/core';
+import { InstrumentationBase, InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { VERSION } from './version';
+
+const MODULE_NAME = 'splunk-visibility';
+let listener: any;
+
+export class SplunkPageVisibilityInstrumentation extends InstrumentationBase {
+
+  constructor(config: InstrumentationConfig = {}) {
+    super(MODULE_NAME, VERSION, Object.assign({}, config));
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  init(): void {}
+
+  enable(): void {
+    if (document.hidden) {
+        console.log('enable doc hidden')
+        this._createSpan(document.hidden);
+    }
+
+    listener = window.addEventListener('visibilitychange', () => {
+        console.log('enable visibility change')
+        this._createSpan(document.hidden);
+    })
+  }
+
+  disable(): void {
+      window.removeEventListener('visibilitychange', listener);
+  }
+
+  private _createSpan(hidden: boolean) {
+    const now = hrTime();
+    const span = this.tracer.startSpan('visibility', { startTime: now });
+    span.setAttribute('hidden', hidden);
+    span.end(now);
+  }
+}
+ 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import { getRumSessionId, initSessionTracking, SessionIdType } from './session';
 import { SplunkWebSocketInstrumentation } from './SplunkWebSocketInstrumentation';
 import { initWebVitals } from './webvitals';
 import { SplunkLongTaskInstrumentation } from './SplunkLongTaskInstrumentation';
+import { SplunkPageVisibilityInstrumentation } from './SplunkPageVisibilityInstrumentation';
 import {
   SplunkPostDocLoadResourceInstrumentation,
   SplunkPostDocLoadResourceInstrumentationConfig,
@@ -62,6 +63,7 @@ interface SplunkOtelWebOptionsInstrumentations {
   fetch?:        boolean | FetchInstrumentationConfig;
   interactions?: boolean | SplunkUserInteractionInstrumentationConfig;
   longtask?:     boolean | InstrumentationConfig;
+  visibility?:   boolean | InstrumentationConfig;
   postload?:     boolean | SplunkPostDocLoadResourceInstrumentationConfig;
   websocket?:    boolean | InstrumentationConfig;
   webvitals?:    boolean;
@@ -155,6 +157,7 @@ const INSTRUMENTATIONS = [
   { Instrument: SplunkWebSocketInstrumentation, confKey: 'websocket', disable: true },
   { Instrument: SplunkLongTaskInstrumentation, confKey: 'longtask', disable: false },
   { Instrument: SplunkErrorInstrumentation, confKey: ERROR_INSTRUMENTATION_NAME, disable: false },
+  { Instrument: SplunkPageVisibilityInstrumentation, confKey: 'visibility', disable: false },
 ] as const;
 
 export const INSTRUMENTATIONS_ALL_DISABLED: SplunkOtelWebOptionsInstrumentations = INSTRUMENTATIONS
@@ -313,6 +316,7 @@ const SplunkRum: SplunkOtelWebType = {
         scheduledDelayMillis: processedOptions.bufferTimeout,
         maxExportBatchSize: processedOptions.bufferSize,
       });
+      
       window.addEventListener('visibilitychange', function() {
         // this condition applies when the page is hidden or when it's closed
         // see for more details: https://developers.google.com/web/updates/2018/07/page-lifecycle-api#developer-recommendations-for-each-state

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,7 @@ const INSTRUMENTATIONS = [
   { Instrument: SplunkWebSocketInstrumentation, confKey: 'websocket', disable: true },
   { Instrument: SplunkLongTaskInstrumentation, confKey: 'longtask', disable: false },
   { Instrument: SplunkErrorInstrumentation, confKey: ERROR_INSTRUMENTATION_NAME, disable: false },
-  { Instrument: SplunkPageVisibilityInstrumentation, confKey: 'visibility', disable: false },
+  { Instrument: SplunkPageVisibilityInstrumentation, confKey: 'visibility', disable: true },
 ] as const;
 
 export const INSTRUMENTATIONS_ALL_DISABLED: SplunkOtelWebOptionsInstrumentations = INSTRUMENTATIONS

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -20,7 +20,6 @@ import SplunkRum, { SplunkExporter, ZipkinSpan } from '../src/index';
 export class SpanCapturer implements SpanProcessor {
   public readonly spans: ReadableSpan[] = [];
   forceFlush(): Promise<void> { return Promise.resolve(); }
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   onStart(): void {}
   shutdown(): Promise<void> { return Promise.resolve(); }
   onEnd(span: ReadableSpan): void {


### PR DESCRIPTION
Captured as 0 duration spans as these can't be complete spans(due to us not being able to close some of them in some case) and we don't have events. Disabled for now cause we need to make sure that sending them is fine. At some point we probably need to add this info to each span so data can be filtered in UI.

Code in index.ts is moved cause otherwise some things fire at wrong times.