### PR TITLE
Async context: Improve hash based router support, note on code splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ If the version of Open Telemetry is unspecified for a version, then it is the sa
 
 ## Unreleased
 
+- Improve asynronous context for hash based routers
+
 ## 0.7.1
 
 Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ If the version of Open Telemetry is unspecified for a version, then it is the sa
 
 ## Unreleased
 
-- Improve asynronous context for hash based routers
+- Improve asynchronous context for hash-based routers
 
 ## 0.7.1
 

--- a/docs/Async-Traces.md
+++ b/docs/Async-Traces.md
@@ -8,7 +8,7 @@ Usually traces that happen asyncronously (for example user interactions that res
 * Promise.then / catch / finally
 * MutationObserver on textNode
 * MessagePort
-* Hash based routers
+* Hash-based routers
 
 These also cover most common methods frameworks use to delay re-renderers when values change, allowing requests done when a component is first rendered to be linked with the user interaction that caused the component to be added to the page.
 
@@ -54,7 +54,7 @@ document.getElementById('save-button').addEventListener('click', async () => {
 });
 ```
 
-There's also limitations when using code splitting - only code loaded by promised based implementations will get linked to parent interaction (eg. [webpack's ìmport() syntax`](https://webpack.js.org/guides/code-splitting/#dynamic-imports))
+There are also limitations when using code splitting: only code loaded by promise-based implementations gets linked to the parent interaction. For an example, see [webpack's ìmport() syntax`](https://webpack.js.org/guides/code-splitting/#dynamic-imports).
 
 ```js
 // src/secret-page.js

--- a/docs/Async-Traces.md
+++ b/docs/Async-Traces.md
@@ -8,6 +8,7 @@ Usually traces that happen asyncronously (for example user interactions that res
 * Promise.then / catch / finally
 * MutationObserver on textNode
 * MessagePort
+* Hash based routers
 
 These also cover most common methods frameworks use to delay re-renderers when values change, allowing requests done when a component is first rendered to be linked with the user interaction that caused the component to be added to the page.
 
@@ -50,5 +51,24 @@ document.getElementById('save-button').addEventListener('click', async () => {
   const saveRes = await fetch('/api/items', {method: 'POST'});
 
   const listRes = await fetch('/api/items'); // Can be disconnected from click event when not transpiled
+});
+```
+
+There's also limitations when using code splitting - only code loaded by promised based implementations will get linked to parent interaction (eg. [webpack's ìmport() syntax`](https://webpack.js.org/guides/code-splitting/#dynamic-imports))
+
+```js
+// src/secret-page.js
+
+// This would not be linked
+const importantData = fetch('/api/secrets');
+
+export function renderPage() {
+  // This would be linked to click if called like shown next
+  const neededData = fetch('/api/needed');
+}
+
+// src/index.js
+document.getElementById('secret-page').addEventListener('click', () => {
+  import('./secret-page.js').then(({renderPage}) => renderPage());
 });
 ```

--- a/integration-tests/tests/context/async-context.spec.js
+++ b/integration-tests/tests/context/async-context.spec.js
@@ -125,5 +125,13 @@ module.exports = {
     await browser.globals.findSpan(span => span.name === 'message-event');
 
     await browser.globals.assertNoErrorSpans();
-  }
+  },
+  'location - hashchange': async function (browser) {
+    await runTest(browser, '/context/location-hash.ejs');
+
+    const clickSpan = await browser.globals.findSpan(span => span.name === 'click');
+    const routeChangeSpan = await browser.globals.findSpan(span => span.name === 'routeChange');
+
+    browser.assert.strictEqual(routeChangeSpan.parentId, clickSpan.id, 'Route change span belongs to user interaction trace.');
+  },
 };

--- a/integration-tests/tests/context/location-hash.ejs
+++ b/integration-tests/tests/context/location-hash.ejs
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>location.hash</title>
+
+  <%- renderAgent({
+    context: {
+      async: true
+    }
+  }) %>
+</head>
+<body>
+  <h1>location.hash</h1>
+
+  <button type="button" id="btn1">Button</button>
+
+  <script>
+    window.addEventListener('hashchange', function () {
+      SplunkRum.provider.getTracer('default').startSpan('context-child').end();
+      window.testing = false;
+    });
+
+    btn1.addEventListener('click', function () {
+      window.testing = true;
+      location.hash = '#!/page';
+    });
+  </script>
+</body>
+</html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -341,11 +341,6 @@ export const SplunkRum: SplunkOtelWebType = {
       provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
     }
 
-    _deregisterInstrumentations = registerInstrumentations({
-      tracerProvider: provider,
-      instrumentations,
-    });
-
     window.addEventListener('visibilitychange', () => {
       // this condition applies when the page is hidden or when it's closed
       // see for more details: https://developers.google.com/web/updates/2018/07/page-lifecycle-api#developer-recommendations-for-each-state
@@ -359,6 +354,13 @@ export const SplunkRum: SplunkOtelWebType = {
         processedOptions.context
       )
     });
+
+    // After context manager registartion so instrumentation event listeners are affected accordingly
+    _deregisterInstrumentations = registerInstrumentations({
+      tracerProvider: provider,
+      instrumentations,
+    });
+
     this.provider = provider;
 
     const vitalsConf = getPluginConfig(processedOptions.instrumentations.webvitals);

--- a/src/index.ts
+++ b/src/index.ts
@@ -355,7 +355,7 @@ export const SplunkRum: SplunkOtelWebType = {
       )
     });
 
-    // After context manager registartion so instrumentation event listeners are affected accordingly
+    // After context manager registration so instrumentation event listeners are affected accordingly
     _deregisterInstrumentations = registerInstrumentations({
       tracerProvider: provider,
       instrumentations,


### PR DESCRIPTION
Improve async context context manager support for hash based routers and add a note to documentation about code split usage.

## Hash based router:

[Angularjs' router](https://github.com/angular/angular.js/blob/9bff2ce8fb170d7a33d3ad551922d7e23e9f82fc/src/ng/browser.js#L242) changes the hash and then waits for browser to fire hashchange event to do rest of the transition (load components, fire them, etc...). Added linking context in that case by watching if location.hash value changed within the function called with contextmanager.with

## Note on lazy loading

We can't link code executed in <script> tag that was loaded by user interaction, so added a note to documentation on how it can be supported.