### PR TITLE
Support single quote in server-timings header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ If the version of Open Telemetry is unspecified for a version, then it is the sa
 Changes:
 
 - Improve asynchronous context for hash-based routers
+- Support both types of quotes on server-timings header values
 
 ## 0.7.1
 

--- a/src/servertiming.ts
+++ b/src/servertiming.ts
@@ -26,7 +26,7 @@ function addMatchToSpan(match: RegExpMatchArray, span: Span): void {
   }
 }
 
-const HeaderRegex = new RegExp('traceparent;desc="00-([0-9a-f]{32})-([0-9a-f]{16})-01"');
+const HeaderRegex = new RegExp('traceparent;desc=[\'"]00-([0-9a-f]{32})-([0-9a-f]{16})-01[\'"]');
 
 export function captureTraceParent(serverTimingValues: string, span: Span): void {
   // getResponseHeader returns multiple Server-Timing headers concat with ', ' (note space)

--- a/test/servertiming.test.ts
+++ b/test/servertiming.test.ts
@@ -32,6 +32,13 @@ describe('test captureTraceParent', () => {
     assert.strictEqual('000000000000000078499d3266d75d5f', span['link.traceId']);
     assert.strictEqual('7e1c10b3c482edbe', span['link.spanId']);
   });
+  it('should deal with single quotes', () => {
+    const span = { setAttribute: function(k,v){this[k] = v;} };
+    // TODO: start an actual span
+    captureTraceParent('traceparent;desc=\'00-000000000000000078499d3266d75d5f-7e1c10b3c482edbe-01\'', span as any);
+    assert.strictEqual('000000000000000078499d3266d75d5f', span['link.traceId']);
+    assert.strictEqual('7e1c10b3c482edbe', span['link.spanId']);
+  });
 });
 
 describe('test captureTraceParentFromPerformanceEntries', () => {


### PR DESCRIPTION
# Description

Have a support case where server-timings header value is inserted with single quotes - PerformanceEntries can process both types of quotes while regexp couldn't, causing only docload to be linked

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- Added unit tests