### PR TITLE
Skip export config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ If the version of Open Telemetry is unspecified for a version, then it is the sa
 
 ## Unreleased
 - Fix Internet Explorer compatibility
+- Add `skipExport` configuration option [#240](https://github.com/signalfx/splunk-otel-js-web/issues/240)
 
 ## 0.8.0
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,12 @@ export interface SplunkOtelWebConfig {
   /** Turns on/off internal debug logging */
   debug?: boolean;
 
+  /** 
+   * Use SplunkOtelWeb as a local tracer provider, but disable all exporting.
+   * If enabled, the values of `beaconUrl` and `debug` will be ignored.
+   */
+  skipExport?: boolean;
+
   /**
    * Sets a value for the `environment` attribute (persists through calls to `setGlobalAttributes()`)
    * */
@@ -261,7 +267,7 @@ export const SplunkRum: SplunkOtelWebType = {
       return;
     }
 
-    if (!processedOptions.debug) {
+    if (!processedOptions.debug && !processedOptions.skipExport) {
       if (!processedOptions.beaconUrl) {
         throw new Error('SplunkRum.init( {beaconUrl: \'https://something\'} ) is required.');
       } else if(!processedOptions.beaconUrl.startsWith('https') && !processedOptions.allowInsecureBeacon) {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -41,6 +41,11 @@ describe('test init', () => {
         assert.ok(SplunkRum.inited === false, 'SplunkRum should not be inited.');
       }
     });
+    it('should allow init in skipExport mode', () => {
+      SplunkRum.init({ beaconUrl: undefined, app: 'app', rumAuth: undefined, skipExport: true });
+      assert.ok(SplunkRum.inited);
+      SplunkRum.deinit();
+    })
   });
   describe('should enforce secure beacon url', () => {
     it('should not be inited with http', () => {


### PR DESCRIPTION
# Description

Adds config option to disable all exporting so that @splunk/otel-web can be used as a local tracer provider / auto-instrumentation source.

Closes #240

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How has this been tested?

- [ ] Manual testing
- [ ] Added unit tests
- [ ] Added integration tests

# Checklist:

- [ ] Changelogs have been updated
- [ ] Unit tests have been added/updated
- [ ] Documentation has been updated
- [ ] Team's resident technical writer tagged on the PR (if there are changes to the documentation)
