### PR TITLE
Handle undefined errors more gracefully

### DIFF
--- a/integration-tests/tests/errors/index.spec.js
+++ b/integration-tests/tests/errors/index.spec.js
@@ -100,6 +100,21 @@ module.exports = {
     await browser.assert.strictEqual(tags['error.object'], 'String');
     await browser.assert.strictEqual(tags['error.message'], 'rejection-value');
   },
+  'unhandled promise rejection (undefined)': async function(browser) {
+    if (isBrowser(browser, 'ie')) {
+      return; // No native promise
+    }
+    await browser.url(browser.globals.getUrl('/errors/views/unhandled-rejection.undefined.ejs'));
+
+    const errorSpan = await browser.globals.findSpan(s => s.name === 'unhandledrejection');
+    await browser.assert.ok(!!errorSpan, 'Checking presence of error span.');
+
+    const tags = errorSpan.tags;
+    await browser.assert.strictEqual(tags['component'], 'error');
+    await browser.assert.strictEqual(tags['error'], 'true');
+    await browser.assert.strictEqual(tags['error.object'], 'String');
+    await browser.assert.strictEqual(tags['error.message'], '(undefined)');
+  },
   'manual console.error': async function(browser) {
     const browserName = browser.options.desiredCapabilities.browserName.toLowerCase();
     

--- a/integration-tests/tests/errors/views/unhandled-rejection.undefined.ejs
+++ b/integration-tests/tests/errors/views/unhandled-rejection.undefined.ejs
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Errors test</title>
+  <%- renderAgent({}) %>
+  <script id="scenario">
+    setTimeout(function() {
+      Promise.reject();
+    });
+  </script>
+</head>
+<body>
+  <h1>Unhandled rejection (undefined)</h1>
+  <pre id="scenarioDisplay"></pre>
+  <script>scenarioDisplay.innerHTML = scenario.innerHTML;</script>
+</body>
+</html>

--- a/src/SplunkErrorInstrumentation.ts
+++ b/src/SplunkErrorInstrumentation.ts
@@ -30,6 +30,14 @@ function useful(s) {
   return s && s.trim() !== '' && !s.startsWith('[object') && s !== 'error';
 }
 
+function stringifyValue(value: unknown) {
+  if (value === undefined) {
+    return '(undefined)';
+  }
+
+  return value.toString();
+}
+
 function addStackIfUseful(span: Span, err: Error) {
   if (err && err.stack && useful(err.stack)) {
     span.setAttribute('error.stack', limitLen(err.stack.toString(), STACK_LIMIT));
@@ -157,9 +165,9 @@ export class SplunkErrorInstrumentation extends InstrumentationBase {
     } else if (arg instanceof Array) {
       // if any arguments are Errors then add the stack trace even though the message is handled differently
       const firstError = arg.find(x => x instanceof Error);
-      this.reportString(source, arg.map(x => x.toString()).join(' '), firstError);
+      this.reportString(source, arg.map(x => stringifyValue(x)).join(' '), firstError);
     } else {
-      this.reportString(source, (arg as any).toString()); // FIXME or JSON.stringify?
+      this.reportString(source, stringifyValue(arg)); // FIXME or JSON.stringify?
     }
   }
 }


### PR DESCRIPTION
```js
Promise.reject()
```

Causes error instrumentation to break on `arg.toString()`