### PR TITLE
Use SplunkRumNative.getNativeSessionId when present

### DIFF
--- a/integration-tests/tests/native/native.ejs
+++ b/integration-tests/tests/native/native.ejs
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+       <meta charset="UTF-8">
+       <title>Native</title>
+       <script>
+               window.SplunkRumNative = {
+                       getNativeSessionId: function() {
+                               return '12341234123412341234123412341234';
+                       }
+               };
+       </script>
+
+       <%- renderAgent({debug: true}) %>
+
+       <style>
+               #container {
+                       height: 200px;
+                       width: 400px;
+               }
+       </style>
+</head>
+<body>
+       <h1>Native</h1>
+</body>
+</html>

--- a/integration-tests/tests/native/native.spec.js
+++ b/integration-tests/tests/native/native.spec.js
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module.exports = {
+  'native session id integration': async function(browser) {
+    const url = browser.globals.getUrl('/native/native.ejs');
+    await browser.url(url);
+
+    const anySpan = await browser.globals.findSpan(span => span.tags['splunk.rumSessionId'] !== undefined);
+
+    await browser.assert.ok(anySpan);
+
+    await browser.assert.strictEqual(anySpan.tags['splunk.rumSessionId'], '12341234123412341234123412341234');
+    await browser.globals.assertNoErrorSpans();
+  }
+};


### PR DESCRIPTION
# Description

SplunkRum mobile components support embedding SplunkRumNative into WebView instances.  When present,
prefer the native app's session ID to our cookie.,

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How has this been tested?

- [x] Manual testing (in sample native iOS app with WebKit's WKWebView)
- [ ] Added unit tests
- [x] Added integration tests

