### PR TITLE
Session based sampler, expose tracer configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Please read [Installation.md](./docs/Installation.md) for more info on different
 - [Identifying users](./docs/IdentifyingUsers.md)
 - [Asyncronous traces](./docs/Async-Traces.md)
 - [Exporters](./docs/Exporters.md)
+- [Sampling](./docs/Sampling.md)
 - [Context propagation](./docs/ContextPropagation.md)
 - [Data sending](./docs/DataSending.md)
 - [Cookies](./docs/Cookies.md)

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -17,6 +17,8 @@ Below are the different initialization options available for the Agent:
 |`context.async`|`boolean`|`false`|Enables [asyncronous context manager](Async-Traces.md)|
 |`exporter.onAttributesSerializing`|`(a: SpanAttributes, s?: Span) => SpanAttributes`|`(attrs) => attrs`|Provides a callback for modifying span attributes before exporting. An example use case of the serializer is to filter out PII.|
 |`instrumentations`|`object`|See the following chapter|Enables or disables specific instrumentations. More details how to enable or disable the instrumentations in the next chapter.|
+|`tracer`|`object`|[`TracerConfig`](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-sdk-trace-base/src/types.ts)|Configuration options passed to WebTracerProvider. Can be used [to configure sampling](./Sampling.md)|
+
 ## Configuring instrumentations
 In order to enable or disable specific instrumentations in the Browser Agent, you need to change the `capture` configuration parameter. This parameter accepts an object  enabling or disabling specific instrumentations. In addition the `capture` can be used to configure instrumentations. The object structure is simple, consisting of:
 

--- a/docs/Sampling.md
+++ b/docs/Sampling.md
@@ -1,0 +1,90 @@
+# Sampling
+
+Splunk RUM captures all of the data from all of the users by default. This behavior can be configured by passing a [Sampler](https://github.com/open-telemetry/opentelemetry-js-api/blob/main/src/trace/Sampler.ts) to the tracer.
+
+Splunk's distribution of OpenTelemetry Javascript includes following samplers for convenience:
+
+* [AlwaysOffSampler from `@opentelemetry/core`](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-core/src/trace/sampler/AlwaysOffSampler.ts)
+* [AlwaysOnSampler from `@opentelemetry/core`](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-core/src/trace/sampler/AlwaysOnSampler.ts)
+* [ParentBasedSampler from `@opentelemetry/core`](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-core/src/trace/sampler/ParentBasedSampler.ts)
+
+These are added to `SplunkRum.*` allowing use on CDN distribution. For example to only get traces from logged in users:
+
+```html
+<!-- When using from CDN -->
+<script src="https://cdn.signalfx.com/o11y-gdi-rum/latest/splunk-otel-web.js" crossorigin="anonymous"></script>
+<script>
+  var shouldTrace = isUserLoggedIn();
+
+  SplunkRum.init({
+    beaconUrl: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
+    rumAuth: '<RUM access token>',
+    app: '<application-name>',
+    tracer: {
+      sampler: shouldTrace ? new SplunkRum.AlwaysOnSampler() : new SplunkRum.AlwaysOffSampler(),
+    },
+  });
+</script>
+```
+
+```js
+// When using NPM you can get samplers directly from @opentelemetry/core
+import {AlwaysOnSampler, AlwaysOffSampler} from '@opentelemetry/core';
+import SplunkOtelWeb from '@splunk/otel-web';
+
+SplunkOtelWeb.init({
+  beaconUrl: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
+  rumAuth: '<RUM access token>',
+  app: '<application-name>',
+  tracer: {
+    sampler: userShouldBeTraced() ? new SplunkRum.AlwaysOnSampler() : new SplunkRum.AlwaysOffSampler(),
+  },
+});
+```
+
+## Session Based Sampler
+
+Splunk's Distribution of OpenTelemetry also includes a custom sampler that is integrated with our sessions support. This should be preferred over trace ratio based sampler as it would lead to partially reported data from all of the sessions, causing more confusion over randomly missing spans.
+
+Session based sampler can be accessed from `SplunkRum.SessionBasedSampler` in CDN build and from `SessionBasedSampler` export when using Splunk RUM via NPM. It accepts a configuration object:
+
+|Option|Type|Default value|Description|
+|---|---|---|---|
+|`ratio`|`number`|`1.0`|Determines the percentage of sessions reported (from 0.0 = no sessions to 1.0 = all sessions)|
+|`sampled`|`Sampler`|`AlwaysOnSampler`|Sampler used when session should be sampled|
+|`notSampled`|`Sampler`|`AlwaysOffSampler`|Sampler used when session should not be sampled|
+
+To capture data from half of the sessions:
+
+```html
+<!-- When using from CDN -->
+<script src="https://cdn.signalfx.com/o11y-gdi-rum/latest/splunk-otel-web.js" crossorigin="anonymous"></script>
+<script>
+  SplunkRum.init({
+    beaconUrl: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
+    rumAuth: '<RUM access token>',
+    app: '<application-name>',
+    tracer: {
+      sampler: new SplunkRum.SessionBasedSampler({
+        ratio: 0.5
+      }),
+    },
+  });
+</script>
+```
+
+```js
+// When using via NPM it is exported from the package
+import SplunkOtelWeb, {SessionBasedSampler} from '@splunk/otel-web';
+
+SplunkOtelWeb.init({
+  beaconUrl: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
+  rumAuth: '<RUM access token>',
+  app: '<application-name>',
+  tracer: {
+    sampler: new SessionBasedSampler({
+      ratio: 0.5
+    }),
+  },
+});
+```

--- a/src/SessionBasedSampler.ts
+++ b/src/SessionBasedSampler.ts
@@ -63,20 +63,10 @@ export class SessionBasedSampler implements Sampler {
 
   shouldSample(context: Context, traceId: string, spanName: string, spanKind: SpanKind, attributes: SpanAttributes, links: Link[]): SamplingResult {
     const currentSession = getRumSessionId();
-    console.log('old sample?', {
-      currentSession,
-      prevSession: this._currentSession,
-      prevSessionSampled: this._currentSessionSampled,
-    });
     if (this._currentSession !== currentSession) {
       this._currentSessionSampled = this._accumulate(currentSession) < this._upperBound;
       this._currentSession = currentSession;
     }
-    console.log('new sample!', {
-      currentSession,
-      prevSession: this._currentSession,
-      prevSessionSampled: this._currentSessionSampled,
-    });
 
     const sampler = (this._currentSessionSampled ? this._sampled : this._notSampled);
 

--- a/src/SessionBasedSampler.ts
+++ b/src/SessionBasedSampler.ts
@@ -62,6 +62,9 @@ export class SessionBasedSampler implements Sampler {
   }
 
   shouldSample(context: Context, traceId: string, spanName: string, spanKind: SpanKind, attributes: SpanAttributes, links: Link[]): SamplingResult {
+    // Implementation based on @opentelemetry/core TraceIdRatioBasedSampler
+    // but replacing deciding based on traceId with sessionId
+    // (not extended from due to private methods)
     const currentSession = getRumSessionId();
     if (this._currentSession !== currentSession) {
       this._currentSessionSampled = this._accumulate(currentSession) < this._upperBound;

--- a/src/SessionBasedSampler.ts
+++ b/src/SessionBasedSampler.ts
@@ -1,0 +1,104 @@
+/*
+Copyright 2021 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Context, Link, Sampler, SamplingResult, SpanAttributes, SpanKind } from '@opentelemetry/api';
+import { AlwaysOffSampler, AlwaysOnSampler } from '@opentelemetry/core';
+import { getRumSessionId } from './session';
+
+export interface SessionBasedSamplerConfig {
+  /**
+   * Ratio of sessions that get sampled (0.0 - 1.0, where 1 is all sessions)
+   */
+  ratio?: number;
+
+  /**
+   * Sampler called when session is being sampled
+   * default: AlwaysOnSampler
+   */
+  sampled?: Sampler;
+
+  /**
+   * Sampler called when session isn't being sampled
+   * default: AlwaysOffSampler
+   */
+  notSampled?: Sampler;
+}
+
+export class SessionBasedSampler implements Sampler {
+  protected _ratio: number;
+  protected _upperBound: number;
+  protected _sampled: Sampler;
+  protected _notSampled: Sampler;
+
+  protected _currentSession: string;
+  protected _currentSessionSampled: boolean;
+
+  // eslint-disable-next-line no-useless-constructor
+  constructor(
+    {
+      ratio = 1,
+      sampled = new AlwaysOnSampler(),
+      notSampled = new AlwaysOffSampler(),
+    }: SessionBasedSamplerConfig = {}
+  ) {
+    this._ratio = this._normalize(ratio);
+    this._upperBound = Math.floor(this._ratio * 0xffffffff);
+
+    this._sampled = sampled;
+    this._notSampled = notSampled;
+  }
+
+  shouldSample(context: Context, traceId: string, spanName: string, spanKind: SpanKind, attributes: SpanAttributes, links: Link[]): SamplingResult {
+    const currentSession = getRumSessionId();
+    console.log('old sample?', {
+      currentSession,
+      prevSession: this._currentSession,
+      prevSessionSampled: this._currentSessionSampled,
+    });
+    if (this._currentSession !== currentSession) {
+      this._currentSessionSampled = this._accumulate(currentSession) < this._upperBound;
+      this._currentSession = currentSession;
+    }
+    console.log('new sample!', {
+      currentSession,
+      prevSession: this._currentSession,
+      prevSessionSampled: this._currentSessionSampled,
+    });
+
+    const sampler = (this._currentSessionSampled ? this._sampled : this._notSampled);
+
+    return sampler.shouldSample(context, traceId, spanName, spanKind, attributes, links);
+  }
+
+  toString(): string {
+    return `SessionBased{ratio=${this._ratio}, sampled=${this._sampled.toString()}, notSampled=${this._notSampled.toString()}}`;
+  }
+
+  private _normalize(ratio: number): number {
+    if (typeof ratio !== 'number' || isNaN(ratio)) {return 0;}
+    return ratio >= 1 ? 1 : ratio <= 0 ? 0 : ratio;
+  }
+
+  private _accumulate(sessionId: string): number {
+    let accumulation = 0;
+    for (let i = 0; i < sessionId.length / 8; i++) {
+      const pos = i * 8;
+      const part = parseInt(sessionId.slice(pos, pos + 8), 16);
+      accumulation = (accumulation ^ part) >>> 0;
+    }
+    return accumulation;
+  }
+}

--- a/src/throwIfUnsupportedBrowser.ts
+++ b/src/throwIfUnsupportedBrowser.ts
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { AlwaysOffSampler, AlwaysOnSampler, ParentBasedSampler } from '@opentelemetry/core';
+import { SessionBasedSampler } from './SessionBasedSampler';
+
 if( typeof Symbol !== 'function') {
   const noop = function(){};
   window.SplunkRum = {
@@ -23,6 +26,10 @@ if( typeof Symbol !== 'function') {
     error: noop,
     setGlobalAttributes: noop,
     deinit: noop,
+    AlwaysOnSampler,
+    AlwaysOffSampler,
+    ParentBasedSampler,
+    SessionBasedSampler,
     _internalInit: noop,
     _experimental_addEventListener: noop,
     _experimental_getGlobalAttributes: () => ({}),

--- a/test/SessionBasedSampler.test.ts
+++ b/test/SessionBasedSampler.test.ts
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import * as assert from 'assert';
+import { InternalEventTarget } from '../src/EventTarget';
+import { SessionBasedSampler } from '../src/SessionBasedSampler';
+import { initSessionTracking, COOKIE_NAME, updateSessionStatus } from '../src/session';
+import { context, SamplingDecision } from '@opentelemetry/api';
+
+describe('Session based sampler', () => {
+  it('decide sampling based on session id and ratio', () => {
+    // Session id < target ratio
+    const lowSessionId = '0'.repeat(32);
+    const lowCookieValue = encodeURIComponent(JSON.stringify({ id: lowSessionId, startTime: new Date().getTime() }));
+    document.cookie = COOKIE_NAME + '=' + lowCookieValue + '; path=/; max-age=' + 10;
+    initSessionTracking(lowSessionId, new InternalEventTarget());
+
+    const sampler = new SessionBasedSampler({ ratio: 0.5 });
+    assert.strictEqual(
+      sampler.shouldSample(context.active(), '0000000000000000', 'test', 0, {}, []).decision,
+      SamplingDecision.RECORD_AND_SAMPLED,
+      'low session id should be recorded'
+    );
+
+    // Session id > target ratio
+    const highSessionId = '1234567890abcdeffedcba0987654321';
+    const highCookieValue = encodeURIComponent(JSON.stringify({ id: highSessionId, startTime: new Date().getTime() }));
+    document.cookie = COOKIE_NAME + '=' + highCookieValue + '; path=/; max-age=' + 10;
+    updateSessionStatus();
+
+    assert.strictEqual(
+      sampler.shouldSample(context.active(), '0000000000000000', 'test', 0, {}, []).decision,
+      SamplingDecision.NOT_RECORD,
+      'high session id should not be recorded'
+    );
+  });
+});

--- a/test/index.ts
+++ b/test/index.ts
@@ -23,6 +23,7 @@ import './servertiming.test';
 import './utils.test';
 import './session.test';
 import './websockets.test';
+import './SessionBasedSampler.test';
 import './SplunkExporter.test';
 import './api.test';
 import './SplunkContextManager.test';


### PR DESCRIPTION
# Description

- Allows configuring tracer
- Adds custom sampler that uses session id to determine if traces should be sampled

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

# How has this been tested?

- Manual testing
- Added unit tests