### PR TITLE
Cleanup upstreamed patches & fix angular

### DIFF
--- a/integration-tests/tests/user-interaction/causality.spec.js
+++ b/integration-tests/tests/user-interaction/causality.spec.js
@@ -20,6 +20,10 @@ module.exports = {
   },
   'handles causality of a mouse click': async function(browser) {
     await browser.url(browser.globals.getUrl('/user-interaction/causality.ejs'));
+
+    // Do a click so web-vitals can run and then remove it's event listeners
+    await browser.click('body');
+
     await browser.click('#btn1');
 
     const clickSpan = await browser.globals.findSpan(span => span.name === 'click');

--- a/integration-tests/tests/user-interaction/causality.spec.js
+++ b/integration-tests/tests/user-interaction/causality.spec.js
@@ -26,7 +26,7 @@ module.exports = {
 
     await browser.click('#btn1');
 
-    const clickSpan = await browser.globals.findSpan(span => span.name === 'click');
+    const clickSpan = await browser.globals.findSpan(span => span.name === 'click' && span.tags['target_xpath'] === '//*[@id="btn1"]');
     await browser.assert.ok(!!clickSpan, 'Checking click span presence.');
 
     const fetchSpan = await browser.globals.findSpan(span => span.tags['http.url'] === '/some-data');

--- a/src/SplunkUserInteractionInstrumentation.ts
+++ b/src/SplunkUserInteractionInstrumentation.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { context, diag, Span, trace, Tracer, TracerProvider } from '@opentelemetry/api';
+import { Span, trace, Tracer, TracerProvider } from '@opentelemetry/api';
 import { hrTime } from '@opentelemetry/core';
-import { InstrumentationConfig, isWrapped } from '@opentelemetry/instrumentation';
+import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import { UserInteractionInstrumentation } from '@opentelemetry/instrumentation-user-interaction';
 
 export type UserInteractionEventsConfig = {

--- a/src/SplunkUserInteractionInstrumentation.ts
+++ b/src/SplunkUserInteractionInstrumentation.ts
@@ -75,52 +75,22 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
       return _superCreateSpan(element, eventName, parentSpan);
     };
 
-    // open-telemetry/opentelemetry-js-contrib#643 - wrong this in event listeners
-    (this as any)._patchAddEventListener = function() {
-      // eslint-disable-next-line @typescript-eslint/no-this-alias
-      const plugin = this;
-      return (original: EventTarget['addEventListener']) => {
-        // eslint-disable-next-line consistent-return
-        return function addEventListenerPatched(
-          this: HTMLElement,
-          type: any,
-          listener: any,
-          useCapture: any
-        ) {
-          const once = useCapture && useCapture.once;
-          const patchedListener = function (this: HTMLElement, ...args: any[]) {
-            let parentSpan: Span | undefined;
-            const event: Event | undefined = args[0];
-            const target = event?.target;
-            if (event) {
-              parentSpan = plugin._eventsSpanMap.get(event);
-            }
-            if (once) {
-              plugin.removePatchedListener(this, type, listener);
-            }
-            const span = plugin._createSpan(target, type, parentSpan);
-            if (span) {
-              if (event) {
-                plugin._eventsSpanMap.set(event, span);
-              }
-              return context.with(
-                trace.setSpan(context.active(), span),
-                () => {
-                  const result = plugin._invokeListener(listener, this, args);
-                  // no zone so end span immediately
-                  span.end();
-                  return result;
-                }
-              );
-            } else {
-              return plugin._invokeListener(listener, this, args);
-            }
-          };
-          if (plugin.addPatchedListener(this, type, listener, patchedListener)) {
-            return original.call(this, type, patchedListener, useCapture);
-          }
-        };
-      };
+    // fix bug: angular checks passive event listener support with "null" event listener,
+    // which cannot be used as a WeakMap key
+    const _origAddPatchedListener = (this as any).addPatchedListener.bind(this);
+    (this as any).addPatchedListener = (
+      on: HTMLElement,
+      type: string,
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      listener: Function | EventListenerObject,
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      wrappedListener: Function
+    ) => {
+      if (!listener) {
+        return true;
+      }
+
+      return _origAddPatchedListener(on, type, listener, wrappedListener);
     };
   }
 
@@ -142,42 +112,11 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
     // Hash can be changed with location.hash = '#newThing', no way to hook that directly...
     window.addEventListener('hashchange', this.__hashChangeHandler);
 
-    // Current parent implementation patches HTMLElement's prototype, which causes it to miss document.addEvenetListener:
-    // HTMLElementPrototype -> ElementPrototype -> NodePrototype -> EventTargetPrototype -> Object
-    // HTMLDocumentPrototype -> DocumentPrototype -> NodePrototype -> EventTargetPrototype -> Object
-    // Most browsers have addEventListener on EventTargetPrototype, except for IE for which it doesn't exist and uses NodePrototype
-    if (this.getZoneWithPrototype()) {
-      super.enable();
-    } else {
-      (this as any)._zonePatched = false;
-      if (isWrapped(Node.prototype.addEventListener)) {
-        this._unwrap(Node.prototype, 'addEventListener');
-        diag.debug('removing previous patch from method addEventListener');
-      }
-      if (isWrapped(Node.prototype.removeEventListener)) {
-        this._unwrap(Node.prototype, 'removeEventListener');
-        diag.debug('removing previous patch from method removeEventListener');
-      }
-      this._wrap(Node.prototype, 'addEventListener', (this as any)._patchAddEventListener());
-      this._wrap(Node.prototype, 'removeEventListener', (this as any)._patchRemoveEventListener());
-
-      this._patchHistoryApi();
-    }
+    super.enable();
   }
 
   disable(): void {
-    // parent unwraps calls to addEventListener so call before us
-    if ((this as any)._zonePatched) {
-      super.disable();
-    } else {
-      if (isWrapped(Node.prototype.addEventListener)) {
-        this._unwrap(Node.prototype, 'addEventListener');
-      }
-      if (isWrapped(Node.prototype.removeEventListener)) {
-        this._unwrap(Node.prototype, 'removeEventListener');
-      }
-      this._unpatchHistoryApi();
-    }
+    super.disable();
 
     window.removeEventListener('hashchange', this.__hashChangeHandler);
   }

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -494,6 +494,23 @@ describe('can remove wrapped event listeners', () => {
   });
 });
 
+describe('event listener shenanigans', () => {
+  const capturer = new SpanCapturer();
+  beforeEach(() => {
+    initWithDefaultConfig(capturer);
+  });
+  afterEach(() => {
+    deinit();
+  });
+
+  // https://github.com/angular/components/blob/59002e1649123922df3532f4be78c485a73c5bc1/src/cdk/platform/features/passive-listeners.ts#L21
+  it('doesn\'t break on null listener', () => {
+    document.body.addEventListener('test', null);
+    // fails on throwing error
+    document.body.removeEventListener('test', null);
+  });
+});
+
 describe('can produce click events', () => {
   const capturer = new SpanCapturer();
   beforeEach(() => {


### PR DESCRIPTION
# Description

Issues with angular: https://codesandbox.io/s/angular-material-tooltip-fhimx?file=/src/index.html

1. Tooltip location isn't properly updated as while it waits for [ngzone's microtask queue to flush out](https://github.com/angular/components/blob/7dbe9a42829a2e71cca3363e9a97ec0ea45be276/src/material/tooltip/tooltip.ts#L560), the microtask never existed due to us patching Node (as a fix for IE not having EventTarget) vs zone patching EventTarget or Node depending on browser support. Node is before EventTarget in prototype chain so even though zone patches addEventListener later, it will never get called as Node's addEventListener is found first.

    Upstreamed version of the IE fix matches zone's patching = doesn't cause this issue, so fixing by removing our version of the fix. 
2. After angular gets to use zone again there's an issue with [passive event listener feature detection](https://github.com/angular/components/blob/59002e1649123922df3532f4be78c485a73c5bc1/src/cdk/platform/features/passive-listeners.ts#L21) where `null` event listener doesn't work [as a key in weakmap used in otel code](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/e5a65c67ec63e9235f7ddf82b2cd75a5a926f7c8/plugins/web/opentelemetry-instrumentation-user-interaction/src/instrumentation.ts#L199) (TypeError: Invalid value used as weak map key)

    Added a quick check for non-values to `addPatchedListener`.

    Otel doesn't have this issue as it uses zone for event listener tracing if possible. But it's still worth pr-ing a fix to otel, probably should also check other "fun" ways to make event listeners (I think you can pass a string as a listener too, calling the global function with that name? That's also not valid for weakmap)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- Added unit tests