### PR TITLE
Socket.io client instrumentation

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -34,6 +34,7 @@ In order to enable or disable specific instrumentations in the Browser Agent, yo
 |`instrumentations.fetch`|`true`|Enables capturing [fetch requests](Instrumentations.md#instrumentation-xhrfetch) requests.|
 |`instrumentations.interactions`|`true`|Enables capturing [user interactions](Instrumentations.md#instrumentation-user-interactions) (such as clicks or keyboard events).|
 |`instrumentations.longtask`|`true`|Enables capturing [long tasks](Instrumentations.md#instrumentation-long-tasks).|
+|`instrumentations.socketio`|`false`|Enables capturing [socket.io messages](Instrumentations.md#instrumentation-socketio-client).|
 |`instrumentations.postload`|`true`|Enables capturing [resources loaded after load event](Instrumentations.md#instrumentation-post-document-load).|
 |`instrumentations.visibility`|`false`|Enables capturing [visibility events](Instrumentations.md#instrumentation-visibility).|
 |`instrumentations.websockets`|`false`|Enables capturing [websockets](Instrumentations.md#instrumentation-websockets).|
@@ -45,6 +46,7 @@ Some instrumentations, such as interactions module, have additional configuratio
 |Option|Type|Default value|Description|
 |---|---|---|---|
 |`instrumentations.interactions.events`|`{[DOM Event Name]: boolean}`|<pre>{<br>click: true,<br>dblclick: true,<br>mousedown: true,<br>mouseup: true,<br><br>submit: true,<br>reset: true,<br>change: true,<br><br>dragend: true,<br>drop: true,<br><br>ended: true,<br>pause: true,<br>play: true,<br>}<br></pre>|[DOM events](https://developer.mozilla.org/en-US/docs/Web/Events#event_listing) that are captured as user interactions, as captured from `SplunkRum.DEFAULT_AUTO_INSTRUMENTED_EVENTS`|
+|`instrumentations.socketio.target`|`string | socket.io client`|`'io'`|Either the global variable name to which the socket.io client will be loaded, or the io object directly (see the documentation for [socket.io instrumentation](Instrumentations.md#instrumentation-socketio-client))|
 
 ## Changing the configuration: examples
 In situation, where you need to change the default configuration, you need to change the object passed to `SplunkRum.init()` call:

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -46,7 +46,7 @@ Some instrumentations, such as interactions module, have additional configuratio
 |Option|Type|Default value|Description|
 |---|---|---|---|
 |`instrumentations.interactions.events`|`{[DOM Event Name]: boolean}`|<pre>{<br>click: true,<br>dblclick: true,<br>mousedown: true,<br>mouseup: true,<br><br>submit: true,<br>reset: true,<br>change: true,<br><br>dragend: true,<br>drop: true,<br><br>ended: true,<br>pause: true,<br>play: true,<br>}<br></pre>|[DOM events](https://developer.mozilla.org/en-US/docs/Web/Events#event_listing) that are captured as user interactions, as captured from `SplunkRum.DEFAULT_AUTO_INSTRUMENTED_EVENTS`|
-|`instrumentations.socketio.target`|`string | socket.io client`|`'io'`|Either the global variable name to which the socket.io client will be loaded, or the io object directly (see the documentation for [socket.io instrumentation](Instrumentations.md#instrumentation-socketio-client))|
+|`instrumentations.socketio.target`|`string | socket.io client`|`'io'`| Either the global variable name to which the socket.io client will be loaded, or the `io` object. See the documentation for [socket.io instrumentation](Instrumentations.md#instrumentation-socketio-client))|
 
 ## Changing the configuration: examples
 In situation, where you need to change the default configuration, you need to change the object passed to `SplunkRum.init()` call:

--- a/docs/Instrumentations.md
+++ b/docs/Instrumentations.md
@@ -213,7 +213,6 @@ Captures information from `send` and `onmessage` events.
 
 This instrumentation generates spans from messages sent using the [socket.io](https://socket.io/) client library. Generated spans conform to the [OpenTelemetry specifications on messaging systems](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md). This instrumentation is disabled by default.
 
-> Enabling websocket instrumentation when using socket.io isn't generally recommended.
 
 ### Setup
 
@@ -268,6 +267,9 @@ When using the CDN distribution of Splunk RUM, enable the socket.io instrumentat
 </script>
 <script src="/app.min.js"></script>
 ```
+
+
+The content of the `app.min.js` file in this example is the following:
 
 ```js
 import { io } from 'socket.io-client';

--- a/docs/Instrumentations.md
+++ b/docs/Instrumentations.md
@@ -211,7 +211,7 @@ Captures information from `send` and `onmessage` events.
 
 ## Instrumentation: Socket.io client
 
-This instrumentation generates spans from messages sent using the [socket.io](https://socket.io/) client library. Generated spans conform to the [OpenTelemetry specifications on messaging systems](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md). This instrumentation is disabled by default.
+This instrumentation generates spans from messages sent using the [socket.io](https://socket.io/) client library. Generated spans conform to the [OpenTelemetry specifications on messaging systems](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md). This instrumentation is disabled by default and versions from v1 to v4 of socket.io-client are supported.
 
 ### Setup
 

--- a/docs/Instrumentations.md
+++ b/docs/Instrumentations.md
@@ -254,7 +254,7 @@ SplunkRum.init({
 
 #### Bundled socket.io client with CDN Splunk RUM installation
 
-When using CDN distribution of Splunk RUM, socket.io instrumentation should be enabled expecting a global object and inside the bundle `io` function should be exposed as `window.io` 
+When using the CDN distribution of Splunk RUM, enable the socket.io instrumentation and expose the `io` function as `window.io`, as in the following example:
 
 ```html
 <script src="/location/to/splunk-otel-web.js"></script>

--- a/docs/Instrumentations.md
+++ b/docs/Instrumentations.md
@@ -213,7 +213,6 @@ Captures information from `send` and `onmessage` events.
 
 This instrumentation generates spans from messages sent using the [socket.io](https://socket.io/) client library. Generated spans conform to the [OpenTelemetry specifications on messaging systems](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md). This instrumentation is disabled by default.
 
-
 ### Setup
 
 #### Socket.io client library served by Socket.io server
@@ -267,7 +266,6 @@ When using the CDN distribution of Splunk RUM, enable the socket.io instrumentat
 </script>
 <script src="/app.min.js"></script>
 ```
-
 
 The content of the `app.min.js` file in this example is the following:
 

--- a/docs/Instrumentations.md
+++ b/docs/Instrumentations.md
@@ -211,7 +211,7 @@ Captures information from `send` and `onmessage` events.
 
 ## Instrumentation: Socket.io client
 
-This instrumentation generates spans from messages sent using [socket.io](https://socket.io/) client library. The generated spans conform to [OpenTelemetry specifications on messaging systems](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md). This instrumentation is disabled by default as it requires a bit more advanced setup.
+This instrumentation generates spans from messages sent using the [socket.io](https://socket.io/) client library. Generated spans conform to the [OpenTelemetry specifications on messaging systems](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md). This instrumentation is disabled by default.
 
 > Enabling websocket instrumentation when using socket.io isn't generally recommended.
 
@@ -219,7 +219,7 @@ This instrumentation generates spans from messages sent using [socket.io](https:
 
 #### Socket.io client library served by Socket.io server
 
-When using [the standalone build server by socket.io server](https://socket.io/docs/v4/client-installation/#standalone-build), instrumentation can be just enabled by passing `true` to configuration.
+When using [the standalone build by socket.io server](https://socket.io/docs/v4/client-installation/#standalone-build), you can enable instrumentation by passing `true` to the configuration setting, like in the following snippet:
 
 ```html
 <script src="/location/to/splunk-otel-web.js"></script>
@@ -236,7 +236,7 @@ When using [the standalone build server by socket.io server](https://socket.io/d
 
 #### Bundled socket.io client with NPM Splunk RUM installation
 
-When using both `@splunk/otel-web` and `socket.io-client` by bundling together, socket.io client should be passed to the instrumentation via `target` config option:
+When using both the `@splunk/otel-web` and the `socket.io-client` packages bundled together, pass the socket.io client to the instrumentation using the `target` config option:
 
 ```js
 import SplunkOtelWeb from '@splunk/otel-web';
@@ -290,13 +290,13 @@ SplunkRum.init({
   },
 });
 
-// Then expose the io object in your bundle by doing:
+// Expose the io object in your bundle
 window.socketIoClient = io;
 ```
 
 ### Spans
 
-Messages sent between socket.io client and server are sent as `EVENT_NAME send` (client -> server) or `EVENT_NAME receive` (server -> client) spans with the following tags:
+Messages sent between socket.io clients and servers are `EVENT_NAME send` (client to server) or `EVENT_NAME receive` (server to client) spans with the following tags:
 
 |Name|Type|Description|
 |---|---|---|

--- a/integration-tests/tests/socketio/socketio.before.ejs
+++ b/integration-tests/tests/socketio/socketio.before.ejs
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Socket.io</title>
+
+  <script src="/socket.io/socket.io.js"></script>
+	<%- renderAgent({instrumentations: {socketio: true}}) %>
+</head>
+<body>
+	<h1>Socket.io</h1>
+	<button id="connectSocket" type="button">Connect to a socket.io server</button>
+	<button id="sendHello" type="button">Send</button>
+	<button id="sendPing" type="button">Ping</button>
+	<script>
+		var socket;
+		connectSocket.addEventListener('click', function () {
+			socket = io();
+			socket.on('pong', function () {
+				window.testing = false;
+				console.log('Pong!');
+			});
+		});
+
+		sendHello.addEventListener('click', function() {
+			socket.emit('hello');
+		});
+
+		sendHello.addEventListener('click', function() {
+			window.testing = true;
+			socket.emit('ping');
+		});
+	</script>
+</body>
+</html>

--- a/integration-tests/tests/socketio/socketio.ejs
+++ b/integration-tests/tests/socketio/socketio.ejs
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Socket.io</title>
+
+	<%- renderAgent({instrumentations: {socketio: true}}) %>
+</head>
+<body>
+	<h1>Socket.io</h1>
+	<button id="connectSocket" type="button">Connect to a socket.io server</button>
+	<button id="sendHello" type="button">Send</button>
+	<button id="sendPing" type="button">Ping</button>
+  <script src="/socket.io/socket.io.js"></script>
+	<script>
+		var socket;
+		connectSocket.addEventListener('click', function () {
+			socket = io();
+			socket.on('pong', function () {
+				window.testing = false;
+				console.log('Pong!');
+			});
+		});
+
+		sendHello.addEventListener('click', function() {
+			socket.emit('hello');
+		});
+
+		sendPing.addEventListener('click', function() {
+			window.testing = true;
+			socket.emit('ping');
+		});
+
+	</script>
+</body>
+</html>

--- a/integration-tests/tests/socketio/socketio.spec.js
+++ b/integration-tests/tests/socketio/socketio.spec.js
@@ -1,0 +1,59 @@
+/*
+Copyright 2022 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module.exports = {
+  beforeEach : function(browser) {
+    browser.globals.clearReceivedSpans();
+  },
+  'produces correct connect span': async function(browser) {
+    const url = browser.globals.getUrl('/socketio/socketio.ejs');
+    await browser.url(url);
+
+    await browser.click('#connectSocket');
+    await browser.click('#sendHello');
+    await browser.click('#sendPing');
+
+    await browser.globals.waitForTestToFinish();
+    await browser.globals.findSpan(span => span.name === 'pong receive');
+
+    const sioSpans = await browser.globals.getReceivedSpans().filter(span => span.tags['messaging.system'] === 'socket.io');
+
+    await browser.assert.strictEqual(sioSpans.length, 3);
+
+    await browser.assert.strictEqual(sioSpans[0].name, 'hello send');
+    await browser.assert.strictEqual(sioSpans[1].name, 'ping send');
+    await browser.assert.strictEqual(sioSpans[2].name, 'pong receive');
+  },
+  'produces correct connect span (socket.io already on page)': async function(browser) {
+    const url = browser.globals.getUrl('/socketio/socketio.before.ejs');
+    await browser.url(url);
+
+    await browser.click('#connectSocket');
+    await browser.click('#sendHello');
+    await browser.click('#sendPing');
+
+    await browser.globals.waitForTestToFinish();
+    await browser.globals.findSpan(span => span.name === 'pong receive');
+
+    const sioSpans = await browser.globals.getReceivedSpans().filter(span => span.tags['messaging.system'] === 'socket.io');
+
+    await browser.assert.strictEqual(sioSpans.length, 3);
+
+    await browser.assert.strictEqual(sioSpans[0].name, 'hello send');
+    await browser.assert.strictEqual(sioSpans[1].name, 'ping send');
+    await browser.assert.strictEqual(sioSpans[2].name, 'pong receive');
+  },
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,10 +31,20 @@ module.exports = function (config) {
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: '',
 
+    plugins: [
+      'karma-chrome-launcher',
+      'karma-coverage-istanbul-reporter',
+      'karma-firefox-launcher',
+      'karma-mocha',
+      'karma-rollup-preprocessor',
+      'karma-spec-reporter',
+      'karma-websocket-server',
+      require('./test/plugins/socketio-server.js')
+    ],
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['mocha', 'websocket-server'],
+    frameworks: ['mocha', 'websocket-server', 'socketio-server'],
     client: {
       mocha: {
         timeout: 6000

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "browserstack-local": "^1.4.8",
         "chai": "^4.3.4",
         "chrome-launcher": "^0.14.0",
-        "chromedriver": "^95.0.0",
+        "chromedriver": "^97.0.0",
         "codecov": "^3.8.2",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
@@ -5359,9 +5359,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "95.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-95.0.0.tgz",
-      "integrity": "sha512-HwSg7S0ZZYsHTjULwxFHrrUqEpz1+ljDudJM3eOquvqD5QKnR5pSe/GlBTY9UU2tVFRYz8bEHYC4Y8qxciQiLQ==",
+      "version": "97.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-97.0.0.tgz",
+      "integrity": "sha512-SZ9MW+/6/Ypz20CNdRKocsmRM2AJ/YwHaWpA1Np2QVPFUbhjhus6vBtqFD+l8M5qrktLWPQSjTwIsDckNfXIRg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -21472,9 +21472,9 @@
       }
     },
     "chromedriver": {
-      "version": "95.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-95.0.0.tgz",
-      "integrity": "sha512-HwSg7S0ZZYsHTjULwxFHrrUqEpz1+ljDudJM3eOquvqD5QKnR5pSe/GlBTY9UU2tVFRYz8bEHYC4Y8qxciQiLQ==",
+      "version": "97.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-97.0.0.tgz",
+      "integrity": "sha512-SZ9MW+/6/Ypz20CNdRKocsmRM2AJ/YwHaWpA1Np2QVPFUbhjhus6vBtqFD+l8M5qrktLWPQSjTwIsDckNfXIRg==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,8 @@
         "saucelabs": "^7.0.1",
         "selenium-server": "^3.141.59",
         "sinon": "^11.1.1",
+        "socket.io": "^4.4.0",
+        "socket.io-client": "^4.4.1",
         "tslib": "^2.2.0",
         "typescript": "^4.2.4",
         "ws": "^7.4.5",
@@ -3514,6 +3516,12 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
+      "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
+      "dev": true
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -4388,6 +4396,12 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+      "dev": true
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4395,9 +4409,9 @@
       "dev": true
     },
     "node_modules/base64-arraybuffer": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
-      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz",
+      "integrity": "sha512-vFIUq7FdLtjZMhATwDul5RZWv2jpXQ09Pd6jcVEOvIsqCWTRFD/ONHNfyOS8dA/Ippi5dsIgpyKWKZaAKZltbA==",
       "dev": true,
       "engines": {
         "node": ">= 0.6.0"
@@ -7167,33 +7181,74 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-4.1.1.tgz",
-      "integrity": "sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.0.tgz",
+      "integrity": "sha512-ErhZOVu2xweCjEfYcTdkCnEYUiZgkAcBBAhW4jbIvNG8SLU3orAqoJCiytZjYF7eTpVmmCrLDjLIEaPlUAs1uw==",
       "dev": true,
       "dependencies": {
+        "@types/cookie": "^0.4.1",
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
         "cookie": "~0.4.1",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
-        "engine.io-parser": "~4.0.0",
-        "ws": "~7.4.2"
+        "engine.io-parser": "~5.0.0",
+        "ws": "~8.2.3"
       },
       "engines": {
         "node": ">=10.0.0"
       }
     },
-    "node_modules/engine.io-parser": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
-      "integrity": "sha512-xEAAY0msNnESNPc00e19y5heTPX4y/TJ36gr8t1voOaNmTojP9b3oK3BbJLFufW2XFPQaaijpFewm2g2Um3uqA==",
+    "node_modules/engine.io-client": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.1.1.tgz",
+      "integrity": "sha512-V05mmDo4gjimYW+FGujoGmmmxRaDsrVr7AXA3ZIfa04MWM1jOfZfUwou0oNqhNwy/votUDvGDt4JA4QF4e0b4g==",
       "dev": true,
       "dependencies": {
-        "base64-arraybuffer": "0.1.4"
+        "@socket.io/component-emitter": "~3.0.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.0",
+        "has-cors": "1.1.0",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
+        "ws": "~8.2.3",
+        "xmlhttprequest-ssl": "~2.0.0",
+        "yeast": "0.1.2"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.2.tgz",
+      "integrity": "sha512-wuiO7qO/OEkPJSFueuATIXtrxF7/6GTbAO9QLv7nnbjwZ5tYhLm9zxvLwxstRs0dcT0KUlWTjtIOs1T86jt12g==",
+      "dev": true,
+      "dependencies": {
+        "base64-arraybuffer": "~1.0.1"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/engine.io/node_modules/cookie": {
@@ -7206,12 +7261,12 @@
       }
     },
     "node_modules/engine.io/node_modules/ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
       "dev": true,
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
@@ -9049,6 +9104,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+      "dev": true
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -10597,6 +10658,80 @@
         "websocket": "^1.0.22"
       }
     },
+    "node_modules/karma/node_modules/base64-arraybuffer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/karma/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/karma/node_modules/engine.io": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-4.1.1.tgz",
+      "integrity": "sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.4.1",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~4.0.0",
+        "ws": "~7.4.2"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/karma/node_modules/engine.io-parser": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
+      "integrity": "sha512-xEAAY0msNnESNPc00e19y5heTPX4y/TJ36gr8t1voOaNmTojP9b3oK3BbJLFufW2XFPQaaijpFewm2g2Um3uqA==",
+      "dev": true,
+      "dependencies": {
+        "base64-arraybuffer": "0.1.4"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/karma/node_modules/socket.io": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-3.1.2.tgz",
+      "integrity": "sha512-JubKZnTQ4Z8G4IZWtaAZSiRP3I/inpy8c/Bsx2jrwGrTbKeVU5xd6qkKMHpChYeM3dWZSO0QACiGK+obhBNwYw==",
+      "dev": true,
+      "dependencies": {
+        "@types/cookie": "^0.4.0",
+        "@types/cors": "^2.8.8",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "debug": "~4.3.1",
+        "engine.io": "~4.1.0",
+        "socket.io-adapter": "~2.1.0",
+        "socket.io-parser": "~4.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/karma/node_modules/socket.io-adapter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz",
+      "integrity": "sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg==",
+      "dev": true
+    },
     "node_modules/karma/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10604,6 +10739,27 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/karma/node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/keyv": {
@@ -13622,6 +13778,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/parseqs": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+      "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
+      "dev": true
+    },
+    "node_modules/parseuri": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
+      "dev": true
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -15228,30 +15396,57 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-3.1.2.tgz",
-      "integrity": "sha512-JubKZnTQ4Z8G4IZWtaAZSiRP3I/inpy8c/Bsx2jrwGrTbKeVU5xd6qkKMHpChYeM3dWZSO0QACiGK+obhBNwYw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.0.tgz",
+      "integrity": "sha512-bnpJxswR9ov0Bw6ilhCvO38/1WPtE3eA2dtxi2Iq4/sFebiDJQzgKNYA7AuVVdGW09nrESXd90NbZqtDd9dzRQ==",
       "dev": true,
       "dependencies": {
-        "@types/cookie": "^0.4.0",
-        "@types/cors": "^2.8.8",
-        "@types/node": ">=10.0.0",
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
-        "debug": "~4.3.1",
-        "engine.io": "~4.1.0",
-        "socket.io-adapter": "~2.1.0",
-        "socket.io-parser": "~4.0.3"
+        "debug": "~4.3.2",
+        "engine.io": "~6.1.0",
+        "socket.io-adapter": "~2.3.3",
+        "socket.io-parser": "~4.0.4"
       },
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz",
-      "integrity": "sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
+      "integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==",
       "dev": true
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.4.1.tgz",
+      "integrity": "sha512-N5C/L5fLNha5Ojd7Yeb/puKcPWWcoB/A09fEjjNsg91EDVr5twk/OEyO6VT9dlLSUNY85NpW6KBhVMvaLKQ3vQ==",
+      "dev": true,
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.0.0",
+        "backo2": "~1.0.2",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.1.1",
+        "parseuri": "0.0.6",
+        "socket.io-parser": "~4.1.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/socket.io-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.1.tgz",
+      "integrity": "sha512-USQVLSkDWE5nbcY760ExdKaJxCE65kcsG/8k5FDGZVVxpD1pA7hABYXYkCUvxUuYYh/+uQw0N/fvBzfT8o07KA==",
+      "dev": true,
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.0.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/socket.io-parser": {
       "version": "4.0.4",
@@ -17101,6 +17296,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/xregexp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
@@ -17218,6 +17422,12 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
+    },
+    "node_modules/yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+      "dev": true
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -19844,6 +20054,12 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@socket.io/component-emitter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
+      "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
+      "dev": true
+    },
     "@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -20513,6 +20729,12 @@
         "@babel/helper-define-polyfill-provider": "^0.2.2"
       }
     },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -20520,9 +20742,9 @@
       "dev": true
     },
     "base64-arraybuffer": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
-      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz",
+      "integrity": "sha512-vFIUq7FdLtjZMhATwDul5RZWv2jpXQ09Pd6jcVEOvIsqCWTRFD/ONHNfyOS8dA/Ippi5dsIgpyKWKZaAKZltbA==",
       "dev": true
     },
     "base64-js": {
@@ -22735,18 +22957,21 @@
       }
     },
     "engine.io": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-4.1.1.tgz",
-      "integrity": "sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.0.tgz",
+      "integrity": "sha512-ErhZOVu2xweCjEfYcTdkCnEYUiZgkAcBBAhW4jbIvNG8SLU3orAqoJCiytZjYF7eTpVmmCrLDjLIEaPlUAs1uw==",
       "dev": true,
       "requires": {
+        "@types/cookie": "^0.4.1",
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
         "cookie": "~0.4.1",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
-        "engine.io-parser": "~4.0.0",
-        "ws": "~7.4.2"
+        "engine.io-parser": "~5.0.0",
+        "ws": "~8.2.3"
       },
       "dependencies": {
         "cookie": {
@@ -22756,21 +22981,47 @@
           "dev": true
         },
         "ws": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+          "dev": true,
+          "requires": {}
+        }
+      }
+    },
+    "engine.io-client": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.1.1.tgz",
+      "integrity": "sha512-V05mmDo4gjimYW+FGujoGmmmxRaDsrVr7AXA3ZIfa04MWM1jOfZfUwou0oNqhNwy/votUDvGDt4JA4QF4e0b4g==",
+      "dev": true,
+      "requires": {
+        "@socket.io/component-emitter": "~3.0.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.0",
+        "has-cors": "1.1.0",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
+        "ws": "~8.2.3",
+        "xmlhttprequest-ssl": "~2.0.0",
+        "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
           "dev": true,
           "requires": {}
         }
       }
     },
     "engine.io-parser": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
-      "integrity": "sha512-xEAAY0msNnESNPc00e19y5heTPX4y/TJ36gr8t1voOaNmTojP9b3oK3BbJLFufW2XFPQaaijpFewm2g2Um3uqA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.2.tgz",
+      "integrity": "sha512-wuiO7qO/OEkPJSFueuATIXtrxF7/6GTbAO9QLv7nnbjwZ5tYhLm9zxvLwxstRs0dcT0KUlWTjtIOs1T86jt12g==",
       "dev": true,
       "requires": {
-        "base64-arraybuffer": "0.1.4"
+        "base64-arraybuffer": "~1.0.1"
       }
     },
     "enquirer": {
@@ -24186,6 +24437,12 @@
       "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
       "dev": true
     },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+      "dev": true
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -25299,11 +25556,77 @@
         "yargs": "^16.1.1"
       },
       "dependencies": {
+        "base64-arraybuffer": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+          "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=",
+          "dev": true
+        },
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+          "dev": true
+        },
+        "engine.io": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-4.1.1.tgz",
+          "integrity": "sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==",
+          "dev": true,
+          "requires": {
+            "accepts": "~1.3.4",
+            "base64id": "2.0.0",
+            "cookie": "~0.4.1",
+            "cors": "~2.8.5",
+            "debug": "~4.3.1",
+            "engine.io-parser": "~4.0.0",
+            "ws": "~7.4.2"
+          }
+        },
+        "engine.io-parser": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
+          "integrity": "sha512-xEAAY0msNnESNPc00e19y5heTPX4y/TJ36gr8t1voOaNmTojP9b3oK3BbJLFufW2XFPQaaijpFewm2g2Um3uqA==",
+          "dev": true,
+          "requires": {
+            "base64-arraybuffer": "0.1.4"
+          }
+        },
+        "socket.io": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-3.1.2.tgz",
+          "integrity": "sha512-JubKZnTQ4Z8G4IZWtaAZSiRP3I/inpy8c/Bsx2jrwGrTbKeVU5xd6qkKMHpChYeM3dWZSO0QACiGK+obhBNwYw==",
+          "dev": true,
+          "requires": {
+            "@types/cookie": "^0.4.0",
+            "@types/cors": "^2.8.8",
+            "@types/node": ">=10.0.0",
+            "accepts": "~1.3.4",
+            "base64id": "~2.0.0",
+            "debug": "~4.3.1",
+            "engine.io": "~4.1.0",
+            "socket.io-adapter": "~2.1.0",
+            "socket.io-parser": "~4.0.3"
+          }
+        },
+        "socket.io-adapter": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz",
+          "integrity": "sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
+        },
+        "ws": {
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -27808,6 +28131,18 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
+    "parseqs": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+      "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
+      "dev": true
+    },
+    "parseuri": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
+      "dev": true
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -29082,27 +29417,50 @@
       }
     },
     "socket.io": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-3.1.2.tgz",
-      "integrity": "sha512-JubKZnTQ4Z8G4IZWtaAZSiRP3I/inpy8c/Bsx2jrwGrTbKeVU5xd6qkKMHpChYeM3dWZSO0QACiGK+obhBNwYw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.0.tgz",
+      "integrity": "sha512-bnpJxswR9ov0Bw6ilhCvO38/1WPtE3eA2dtxi2Iq4/sFebiDJQzgKNYA7AuVVdGW09nrESXd90NbZqtDd9dzRQ==",
       "dev": true,
       "requires": {
-        "@types/cookie": "^0.4.0",
-        "@types/cors": "^2.8.8",
-        "@types/node": ">=10.0.0",
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
-        "debug": "~4.3.1",
-        "engine.io": "~4.1.0",
-        "socket.io-adapter": "~2.1.0",
-        "socket.io-parser": "~4.0.3"
+        "debug": "~4.3.2",
+        "engine.io": "~6.1.0",
+        "socket.io-adapter": "~2.3.3",
+        "socket.io-parser": "~4.0.4"
       }
     },
     "socket.io-adapter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz",
-      "integrity": "sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
+      "integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==",
       "dev": true
+    },
+    "socket.io-client": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.4.1.tgz",
+      "integrity": "sha512-N5C/L5fLNha5Ojd7Yeb/puKcPWWcoB/A09fEjjNsg91EDVr5twk/OEyO6VT9dlLSUNY85NpW6KBhVMvaLKQ3vQ==",
+      "dev": true,
+      "requires": {
+        "@socket.io/component-emitter": "~3.0.0",
+        "backo2": "~1.0.2",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.1.1",
+        "parseuri": "0.0.6",
+        "socket.io-parser": "~4.1.1"
+      },
+      "dependencies": {
+        "socket.io-parser": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.1.tgz",
+          "integrity": "sha512-USQVLSkDWE5nbcY760ExdKaJxCE65kcsG/8k5FDGZVVxpD1pA7hABYXYkCUvxUuYYh/+uQw0N/fvBzfT8o07KA==",
+          "dev": true,
+          "requires": {
+            "@socket.io/component-emitter": "~3.0.0",
+            "debug": "~4.3.1"
+          }
+        }
+      }
     },
     "socket.io-parser": {
       "version": "4.0.4",
@@ -30592,6 +30950,12 @@
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
     },
+    "xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "dev": true
+    },
     "xregexp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
@@ -30678,6 +31042,12 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,8 @@
     "saucelabs": "^7.0.1",
     "selenium-server": "^3.141.59",
     "sinon": "^11.1.1",
+    "socket.io": "^4.4.0",
+    "socket.io-client": "^4.4.1",
     "tslib": "^2.2.0",
     "typescript": "^4.2.4",
     "ws": "^7.4.5",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "browserstack-local": "^1.4.8",
     "chai": "^4.3.4",
     "chrome-launcher": "^0.14.0",
-    "chromedriver": "^95.0.0",
+    "chromedriver": "^97.0.0",
     "codecov": "^3.8.2",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/src/SplunkSocketIoClientInstrumentation.ts
+++ b/src/SplunkSocketIoClientInstrumentation.ts
@@ -1,0 +1,226 @@
+/*
+Copyright 2021 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { context, trace, SpanKind, SpanStatusCode } from '@opentelemetry/api';
+import { InstrumentationBase, InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { MessagingDestinationKindValues, MessagingOperationValues, SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { waitForGlobal } from './utils';
+import { VERSION } from './version';
+
+const MODULE_NAME = 'splunk-socket.io-client';
+
+/*
+ * Subset of socket.IO parts we patch so we can avoid a hard dependency on
+ * socket.io-client due to types
+ */
+
+interface SocketIOSocket {
+  (...args: unknown[]): unknown;
+
+  prototype: {
+    emit(ev: string, ...args: unknown[]): ThisParameterType<SocketIOSocket>;
+    on(ev: string, listener: (...args: unknown[]) => void): ThisParameterType<SocketIOSocket>
+    addEventListener(ev: string, listener: (...args: unknown[]) => void): ThisParameterType<SocketIOSocket>
+    off(ev?: string, listener?: (...args: unknown[]) => void): ThisParameterType<SocketIOSocket>
+    removeListener(ev?: string, listener?: (...args: unknown[]) => void): ThisParameterType<SocketIOSocket>
+    removeAllListeners(ev?: string): ThisParameterType<SocketIOSocket>
+    removeEventListener(ev?: string, listener?: (...args: unknown[]) => void): ThisParameterType<SocketIOSocket>
+  }
+}
+
+interface SocketIOClient {
+  (...args: unknown[]): unknown;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  Manager: Function;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  Socket: SocketIOSocket;
+}
+
+// Aligned with aspecto's server side socket.io instrumentations
+// https://github.com/aspecto-io/opentelemetry-ext-js/blob/d98dabe288b1d95ce7e3d8b9b2ccc3ed02854392/packages/instrumentation-socket.io/src/types.ts#L8
+const SocketIoInstrumentationAttributes = {
+  SOCKET_IO_ROOMS: 'messaging.socket.io.rooms',
+  SOCKET_IO_NAMESPACE: 'messaging.socket.io.namespace',
+  SOCKET_IO_EVENT_NAME: 'messaging.socket.io.event_name',
+};
+
+export interface SocketIoClientInstrumentationConfig extends InstrumentationConfig {
+  /**
+   * Target object or the key it will be set on on window.
+   * 
+   * Not explicitly typed to avoid dependency on socket-io client
+   */
+  target?: string | SocketIOClient;
+}
+
+function seemsLikeSocketIoClient(io: unknown): io is SocketIOClient {
+  return typeof io === 'function' && typeof (io as SocketIOClient).Socket === 'function';
+}
+
+// Events that can't be emitted over the socket
+// https://github.com/socketio/socket.io-client/blob/eaf782c41b9b92d4f39aa221a4166de4a30fb560/lib/socket.ts#L22
+const RESERVED_EVENTS = ['connect', 'connect_error', 'disconnect', 'disconnecting', 'newListener', 'removeListener'];
+
+export class SplunkSocketIoClientInstrumentation extends InstrumentationBase {
+  protected listeners = new WeakMap<(...args: unknown[]) => void, (...args: unknown[]) => void>();
+
+  constructor(config: SocketIoClientInstrumentationConfig = {}) {
+    super(MODULE_NAME, VERSION, Object.assign({ target: 'io' }, config));
+  }
+
+  _onDisable?: () => void;
+
+  protected init(): void {}
+
+  override getConfig(): SocketIoClientInstrumentationConfig {
+    return this._config;
+  }
+
+  protected patchSocketIo(io: unknown | SocketIOClient): void {
+    if (!seemsLikeSocketIoClient(io)) {
+      this._diag.debug('Doesn\'t seem like socket.io-client', io);
+      return;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const inst = this;
+
+    this._wrap(io.Socket.prototype, 'emit', (original) => {
+      return function (eventName: string, ...args) {
+
+        const span = inst.tracer.startSpan(`${eventName} send`, {
+          kind: SpanKind.PRODUCER,
+          attributes: {
+            [SemanticAttributes.MESSAGING_SYSTEM]: 'socket.io',
+            [SemanticAttributes.MESSAGING_DESTINATION]: this.nsp,
+            [SemanticAttributes.MESSAGING_DESTINATION_KIND]: MessagingDestinationKindValues.TOPIC,
+            [SocketIoInstrumentationAttributes.SOCKET_IO_NAMESPACE]: this.nsp,
+            [SocketIoInstrumentationAttributes.SOCKET_IO_EVENT_NAME]: eventName,
+          },
+        });
+
+        try {
+          return context.with(trace.setSpan(context.active(), span),
+            () => original.apply(this, [eventName, ...args])
+          );
+        } catch (error) {
+          let message: string;
+          if (error instanceof Error) {
+            span.recordException(error);
+            message = error.message;
+          }
+
+          span.setStatus({ code: SpanStatusCode.ERROR, message });
+          throw error;
+        } finally {
+          span.end();
+        }
+      };
+    });
+
+    this._wrap(io.Socket.prototype, 'on', (original) => {
+      return function (eventName: string, listener) {
+        if (RESERVED_EVENTS.includes(eventName) || typeof listener !== 'function') {
+          return original.call(this, eventName, listener);
+        }
+
+        let wrappedListener;
+
+        if (inst.listeners.has(listener)) {
+          wrappedListener = inst.listeners.get(listener);
+        } else {
+          wrappedListener = function (...args: unknown[]) {
+            const span = inst.tracer.startSpan(`${eventName} ${MessagingOperationValues.RECEIVE}`, {
+              kind: SpanKind.CONSUMER,
+              attributes: {
+                [SemanticAttributes.MESSAGING_SYSTEM]: 'socket.io',
+                [SemanticAttributes.MESSAGING_DESTINATION]: this.nsp,
+                [SemanticAttributes.MESSAGING_DESTINATION_KIND]: MessagingDestinationKindValues.TOPIC,
+                [SemanticAttributes.MESSAGING_OPERATION]: MessagingOperationValues.RECEIVE,
+                [SocketIoInstrumentationAttributes.SOCKET_IO_NAMESPACE]: this.nsp,
+                [SocketIoInstrumentationAttributes.SOCKET_IO_EVENT_NAME]: eventName,
+              },
+            });
+
+            try {
+              listener.call(this, args);
+            } catch (error) {
+              if (error instanceof Error) {
+                span.recordException(error);
+              }
+              throw error;
+            } finally {
+              span.end();
+            }
+          };
+          inst.listeners.set(listener, wrappedListener);
+        }
+
+        return original.call(this, eventName, wrappedListener);
+      };
+    });
+    io.Socket.prototype.addEventListener = io.Socket.prototype.on;
+
+    this._wrap(io.Socket.prototype, 'off', (original) => {
+      // all of the remove are implemented as one function
+      // https://github.com/socketio/emitter/blob/cd703fe28e5bf85ecf137b0e6422e2608c0eefbf/index.js#L81
+      return function (eventName?: string, listener?: (...args: unknown[]) => void) {
+        if (!eventName || RESERVED_EVENTS.includes(eventName) || typeof listener !== 'function') {
+          return original.call(this, eventName, listener);
+        }
+
+        if (inst.listeners.has(listener)) {
+          return original.call(this, eventName, inst.listeners.get(listener));
+        } else {
+          return original.call(this, eventName, listener);
+        }
+      };
+    });
+    io.Socket.prototype.removeListener = io.Socket.prototype.off;
+    io.Socket.prototype.removeEventListener = io.Socket.prototype.off;
+    io.Socket.prototype.removeAllListeners = io.Socket.prototype.off;
+
+    this._onDisable = () => {
+      this._unwrap(io.Socket.prototype, 'emit');
+      this._unwrap(io.Socket.prototype, 'on');
+      io.Socket.prototype.addEventListener = io.Socket.prototype.on;
+      this._unwrap(io.Socket.prototype, 'off');
+      io.Socket.prototype.removeListener = io.Socket.prototype.off;
+      io.Socket.prototype.removeEventListener = io.Socket.prototype.off;
+      io.Socket.prototype.removeAllListeners = io.Socket.prototype.off;
+    };
+  }
+
+  enable(): void {
+    const config = this.getConfig();
+
+    if (!config.target) {
+      return;
+    }
+
+    if (typeof config.target === 'string') {
+      this._onDisable = waitForGlobal(config.target, io => this.patchSocketIo(io));
+    } else {
+      this.patchSocketIo(config.target);
+    }
+  }
+
+  disable(): void {
+    if (this._onDisable) {
+      this._onDisable();
+      this._onDisable = undefined;
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ import { VERSION } from './version';
 import { getSyntheticsRunId, SYNTHETICS_RUN_ID_ATTRIBUTE } from './synthetics';
 import { SplunkSpanAttributesProcessor } from './SplunkSpanAttributesProcessor';
 import { SessionBasedSampler } from './SessionBasedSampler';
+import { SocketIoClientInstrumentationConfig, SplunkSocketIoClientInstrumentation } from './SplunkSocketIoClientInstrumentation';
 
 export * from './SplunkExporter';
 export * from './SplunkWebTracerProvider';
@@ -78,6 +79,7 @@ interface SplunkOtelWebOptionsInstrumentations {
   visibility?:   boolean | InstrumentationConfig;
   connectivity?: boolean | InstrumentationConfig;
   postload?:     boolean | SplunkPostDocLoadResourceInstrumentationConfig;
+  socketio?:     boolean | SocketIoClientInstrumentationConfig;
   websocket?:    boolean | InstrumentationConfig;
   webvitals?:    boolean;
   xhr?:          boolean | XMLHttpRequestInstrumentationConfig;
@@ -182,7 +184,8 @@ const INSTRUMENTATIONS = [
   { Instrument: SplunkLongTaskInstrumentation, confKey: 'longtask', disable: false },
   { Instrument: SplunkErrorInstrumentation, confKey: ERROR_INSTRUMENTATION_NAME, disable: false },
   { Instrument: SplunkPageVisibilityInstrumentation, confKey: 'visibility', disable: true },
-  { Instrument: SplunkConnectivityInstrumentation, confKey: 'connectivity', disable: true }
+  { Instrument: SplunkConnectivityInstrumentation, confKey: 'connectivity', disable: true },
+  { Instrument: SplunkSocketIoClientInstrumentation, confKey: 'socketio', disable: true },
 ] as const;
 
 export const INSTRUMENTATIONS_ALL_DISABLED: SplunkOtelWebOptionsInstrumentations = INSTRUMENTATIONS

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -159,7 +159,7 @@ export function waitForGlobal(identifier: string, callback: (value: unknown) => 
 
     delete window[identifier];
     if (value !== undefined) {
-      window[identifier];
+      window[identifier] = value;
     }
   };
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -30,3 +30,4 @@ import './SplunkContextManager.test';
 import './SplunkSpanAttributesProcessor.test';
 import './SplunkOtelWeb.test';
 import './synthetics.test';
+import './socketio.test';

--- a/test/plugins/socketio-server.js
+++ b/test/plugins/socketio-server.js
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const { Server } = require('socket.io');
+
+function initSocketIo() {
+  const io = new Server({
+    cors: {
+      origin: true
+    }
+  });
+
+  io.on('connection', socket => {
+    socket.on('hello', () => {
+      // Does nothing
+    });
+    socket.on('ping', (...args) => {
+      socket.emit('pong', ...args);
+    });
+  });
+
+  io.listen(8980);
+}
+
+module.exports = {
+  'framework:socketio-server': ['factory', initSocketIo]
+};

--- a/test/socketio.test.ts
+++ b/test/socketio.test.ts
@@ -1,0 +1,177 @@
+/*
+Copyright 2022 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import * as assert from 'assert';
+import { deinit, initWithDefaultConfig, SpanCapturer } from './utils';
+import { io } from 'socket.io-client';
+import { SplunkOtelWebConfig } from '../src';
+import { SpanKind } from '@opentelemetry/api';
+
+describe('can produce websocket events', () => {
+  let capturer;
+
+  beforeEach(() => {
+    capturer = new SpanCapturer();
+    initWithDefaultConfig(capturer, {
+      instrumentations: {
+        socketio: {
+          target: io
+        }
+      }
+    } as Partial<SplunkOtelWebConfig>);
+  });
+  afterEach(() => {
+    deinit();
+  });
+
+  it('produces spans from emit', (done) => {
+    const socket = io('http://127.0.0.1:8980');
+    socket.on('connect', () => {
+      socket.emit('hello');
+
+      setTimeout(() => {
+        const sioSpans = capturer.spans.filter(span => span.attributes['messaging.system'] === 'socket.io');
+
+        assert.strictEqual(sioSpans.length, 1, 'Should have 1 socket.io span');
+
+        assert.strictEqual(sioSpans[0].name, 'hello send');
+        assert.strictEqual(sioSpans[0].kind, SpanKind.PRODUCER);
+        assert.strictEqual(sioSpans[0].attributes['messaging.destination'], '/', 'messaging.destination attribute');
+        assert.strictEqual(sioSpans[0].attributes['messaging.socket.io.namespace'], '/', 'messaging.socket.io.namespace attribute');
+        assert.strictEqual(sioSpans[0].attributes['messaging.socket.io.event_name'], 'hello', 'messaging.socket.io.event_name attribute');
+
+        socket.disconnect();
+        done();
+      }, 10);
+    });
+  });
+
+  it('produces spans from event listener', (done) => {
+    const socket = io('http://127.0.0.1:8980');
+
+    socket.on('connect', () => {
+      socket.emit('ping');
+    });
+    socket.on('pong', () => {
+      setTimeout(() => {
+        const sioSpans = capturer.spans.filter(span => span.attributes['messaging.system'] === 'socket.io');
+
+        assert.strictEqual(sioSpans.length, 2, 'Should have 2 socket.io span');
+
+        assert.strictEqual(sioSpans[0].name, 'ping send');
+        assert.strictEqual(sioSpans[1].name, 'pong receive');
+        assert.strictEqual(sioSpans[1].kind, SpanKind.CONSUMER);
+        assert.strictEqual(sioSpans[1].attributes['messaging.destination'], '/', 'messaging.destination attribute');
+        assert.strictEqual(sioSpans[1].attributes['messaging.socket.io.namespace'], '/', 'messaging.socket.io.namespace attribute');
+        assert.strictEqual(sioSpans[1].attributes['messaging.socket.io.event_name'], 'pong', 'messaging.socket.io.event_name attribute');
+
+        socket.disconnect();
+        done();
+      }, 10);
+    });
+  });
+
+  it('removing event listener', (done) => {
+    const socket = io('http://127.0.0.1:8980');
+
+    function tempListener() {
+      assert.fail('Called removed listener');
+    }
+    function connectListener() {
+      socket.off('pong', tempListener);
+      socket.on('pong', () => {
+        assert.ok(true, 'No fails called before this');
+        done();
+      });
+      socket.emit('ping');
+    }
+
+    socket.on('pong', tempListener);
+    socket.on('connect', connectListener);
+  });
+});
+
+describe('window global io', () => {
+  let capturer;
+
+  beforeEach(() => {
+    // @ts-expect-error io isn't standard window prop
+    window.io = io;
+    capturer = new SpanCapturer();
+    initWithDefaultConfig(capturer, {
+      instrumentations: {
+        socketio: true
+      }
+    } as Partial<SplunkOtelWebConfig>);
+  });
+  afterEach(() => {
+    deinit();
+    // @ts-expect-error io isn't standard window prop
+    delete window.io;
+  });
+
+  it('produces spans from emit', (done) => {
+    // @ts-expect-error See beforeEach
+    const socket = (window.io as typeof io)('http://127.0.0.1:8980');
+    socket.on('connect', () => {
+      socket.emit('hello');
+
+      setTimeout(() => {
+        const sioSpans = capturer.spans.filter(span => span.attributes['messaging.system'] === 'socket.io');
+        assert.strictEqual(sioSpans.length, 1, 'Should have 1 socket.io span');
+
+        socket.disconnect();
+        done();
+      }, 10);
+    });
+  });
+});
+
+describe('window global io (loaded after init)', () => {
+  let capturer;
+
+  beforeEach(() => {
+    capturer = new SpanCapturer();
+    initWithDefaultConfig(capturer, {
+      instrumentations: {
+        socketio: true
+      }
+    } as Partial<SplunkOtelWebConfig>);
+    // @ts-expect-error io isn't standard window prop
+    window.io = io;
+  });
+  afterEach(() => {
+    deinit();
+    // @ts-expect-error io isn't standard window prop
+    delete window.io;
+  });
+
+  it('produces spans from emit', (done) => {
+    // @ts-expect-error See beforeEach
+    const socket = (window.io as typeof io)('http://127.0.0.1:8980');
+    socket.on('connect', () => {
+      socket.emit('hello');
+
+      setTimeout(() => {
+        const sioSpans = capturer.spans.filter(span => span.attributes['messaging.system'] === 'socket.io');
+        assert.strictEqual(sioSpans.length, 1, 'Should have 1 socket.io span');
+
+        socket.disconnect();
+        done();
+      }, 10);
+    });
+  });
+});

--- a/test/synthetics.test.ts
+++ b/test/synthetics.test.ts
@@ -44,5 +44,6 @@ describe('synthetics integration', () => {
     const spans = getFinishedSpans();
     expect(spans.length).to.eq(1);
     expect(spans[0].tags[SYNTHETICS_RUN_ID_ATTRIBUTE]).to.eq(undefined);
+    deinit();
   });
 });


### PR DESCRIPTION
# Description

Adds instrumentation to socket.io client that unlike websocket instrumentation follows the [messaging systems](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md) otel spec, as socket.io usage has the structure needed to make it work. It is also made with [aspecto's socket.io server side instrumentation](https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-socket.io) in mind (spans should be similar, tho with a few omissions that don't apply client side).

Since this is the first instrumentation that instruments a separately loaded library (won't always be accessible when RUM is being inited, may not be accessible at all in bundled apps), extra documentation effort was needed to cover multiple possible installation methods.

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

# How has this been tested?

- Manual testing
- Added unit tests
- Added integration tests