### PR TITLE
Filter out invalid CORS network timings

### DIFF
--- a/src/SplunkExporter.ts
+++ b/src/SplunkExporter.ts
@@ -171,6 +171,13 @@ export class SplunkExporter implements SpanExporter {
     for (const [key, value] of Object.entries(span.tags)) {
       span.tags[key] = limitLen(value.toString(), MAX_VALUE_LIMIT);
     }
+    // Remove inaccurate CORS timings
+    const zero = performance.timeOrigin * 1000;
+    if (span.tags['http.url'] && !(span.tags['http.url'] as string).startsWith(location.origin) && span.timestamp > zero && span.annotations) {
+      span.annotations = span.annotations.filter(({ timestamp }) => {
+        return timestamp !== zero;
+      });
+    }
     return span;
   }
 }


### PR DESCRIPTION
# Description

Filter out timings that are before span start caused by missing Timing-Allow-Origin header

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
