### PR TITLE
Call postload context hooks only if instrumentation has been loaded

### DIFF
--- a/integration-tests/tests/resource-observer/resource-obs.spec.js
+++ b/integration-tests/tests/resource-observer/resource-obs.spec.js
@@ -187,5 +187,13 @@ module.exports = {
     await browser.assert.not.ok(plScriptRootSpan.parentId);
     await browser.assert.equal(plScriptParentSpan.traceId, plScriptChildSpan.traceId);
     await browser.assert.equal(plScriptChildSpan.parentId, plScriptParentSpan.id);
+  },
+  'doesn\'t crash when postload instrumentation is disabled': async function(browser) {
+    await browser.url(browser.globals.getUrl('/resource-observer/resources-custom-context.ejs'));
+    await browser.click('#btn1');
+
+    const click = await browser.globals.findSpan(span => span.name === 'click');
+    await browser.assert.ok(click);
+    await browser.global.assertNoErrorSpans();
   }
 };

--- a/integration-tests/tests/resource-observer/resources-postload-disabled.ejs
+++ b/integration-tests/tests/resource-observer/resources-postload-disabled.ejs
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Resource observer test</title>
+  <%- renderAgent({ instrumentations: { postload: false }}) %>
+</head>
+<body>
+  <h1>Resource observer test</h1>
+
+  <button type="button" id="btn1">Button</button>
+
+  <pre id="scenarioDisplay"></pre>
+  <script id="scenario">
+    btn1.addEventListener('click', function () {});
+  </script>
+  <script>scenarioDisplay.innerHTML = scenario.innerHTML;</script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "browserstack-local": "^1.4.8",
         "chai": "^4.3.4",
         "chrome-launcher": "^0.15.0",
-        "chromedriver": "^103.0.0",
+        "chromedriver": "^105.0.0",
         "codecov": "^3.8.2",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
@@ -5261,9 +5261,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "103.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-103.0.0.tgz",
-      "integrity": "sha512-7BHf6HWt0PeOHCzWO8qlnD13sARzr5AKTtG8Csn+czsuAsajwPxdLNtry5GPh8HYFyl+i0M+yg3bT43AGfgU9w==",
+      "version": "105.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-105.0.0.tgz",
+      "integrity": "sha512-BX3GOUW5m6eiW9cVVF8hw+EFxvrGqYCxbwOqnpk8PjbNFqL5xjy7yel+e6ilJPjckAYFutMKs8XJvOs/W85vvg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -18745,9 +18745,9 @@
       }
     },
     "chromedriver": {
-      "version": "103.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-103.0.0.tgz",
-      "integrity": "sha512-7BHf6HWt0PeOHCzWO8qlnD13sARzr5AKTtG8Csn+czsuAsajwPxdLNtry5GPh8HYFyl+i0M+yg3bT43AGfgU9w==",
+      "version": "105.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-105.0.0.tgz",
+      "integrity": "sha512-BX3GOUW5m6eiW9cVVF8hw+EFxvrGqYCxbwOqnpk8PjbNFqL5xjy7yel+e6ilJPjckAYFutMKs8XJvOs/W85vvg==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "browserstack-local": "^1.4.8",
     "chai": "^4.3.4",
     "chrome-launcher": "^0.15.0",
-    "chromedriver": "^103.0.0",
+    "chromedriver": "^105.0.0",
     "codecov": "^3.8.2",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -398,8 +398,8 @@ export const SplunkRum: SplunkOtelWebType = {
     provider.register({
       contextManager: new SplunkContextManager({
         ...processedOptions.context,
-        onBeforeContextStart: () => _postDocLoadInstrumentation.onBeforeContextChange(),
-        onBeforeContextEnd: () => _postDocLoadInstrumentation.onBeforeContextChange(),
+        onBeforeContextStart: () => _postDocLoadInstrumentation?.onBeforeContextChange(),
+        onBeforeContextEnd: () => _postDocLoadInstrumentation?.onBeforeContextChange(),
       })
     });
 


### PR DESCRIPTION
# Description

When postload instrumentation is disabled, any context changes will currently throw with an error

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- Manual testing
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
