### PR TITLE
another release script fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,7 +88,7 @@ release_npm:
   script:
     # release to NPM
     - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-    - for f in artifacts/*.tgz; do npm publish --tag beta $f; done;
+    - for f in artifacts/*.tgz; do npm publish --tag beta ./$f; done;
     - rm -f ~/.npmrc
 
 release_github:


### PR DESCRIPTION
for loop generated command `npm publish artifacts/splunk-otel-web-0.14.0-rc.1.tgz`, since it didn't have . infront it thought it was referencing a github repository called artifacts/splunk-otel-web-0.14.0-rc.1.tgz