### PR TITLE
Use XHR sender by default, increase throughput

### DIFF
--- a/packages/web/src/SplunkExporter.ts
+++ b/packages/web/src/SplunkExporter.ts
@@ -115,7 +115,7 @@ export class SplunkExporter implements SpanExporter {
     spans = spans.filter(span => this._filter(span));
     const zspans = spans.map(span => this._mapToZipkinSpan(span));
     const zJson = JSON.stringify(zspans);
-    if (this._beaconSender) {
+    if (document.hidden && this._beaconSender && zJson.length <= 64000) {
       this._beaconSender(this.beaconUrl, zJson);
     } else {
       this._xhrSender(this.beaconUrl, zJson);

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -169,8 +169,8 @@ interface SplunkOtelWebConfigInternal extends SplunkOtelWebConfig {
 const OPTIONS_DEFAULTS: SplunkOtelWebConfigInternal = {
   app: 'unknown-browser-app',
   beaconUrl: undefined,
-  bufferTimeout: 5000, //millis, tradeoff between batching and loss of spans by not sending before page close
-  bufferSize: 20, // spans, tradeoff between batching and hitting sendBeacon invididual limits
+  bufferTimeout: 4000, //millis, tradeoff between batching and loss of spans by not sending before page close
+  bufferSize: 50, // spans, tradeoff between batching and hitting sendBeacon invididual limits
   instrumentations: {},
   exporter: {
     factory: (options) => new SplunkExporter(options),


### PR DESCRIPTION
# Description

Current beacon usage has issues:

1. Max request payload size (64KB, per request in firefox, in queue in chrome)
2. EasyList by default blocks sendBeacon to third party domains

Changed logic to prefer using XHR sender, unless document is in hidden state (about to be unloaded, or in background)

Ingest has been updated to add CORS header

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Chore or internal change (changes not visible to the consumers of the package)

# How has this been tested?

- Manual testing
- Same integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
