### PR TITLE
Add extra saftey check for value in async context manager

### DIFF
--- a/packages/web/integration-tests/tests/context/location-hash.ejs
+++ b/packages/web/integration-tests/tests/context/location-hash.ejs
@@ -12,6 +12,9 @@
   <button type="button" id="btn1">Button</button>
 
   <script>
+    // Check that getter doesn't throw if none set
+    window.onhashchange;
+
     window.addEventListener('hashchange', function () {
       SplunkRum.provider.getTracer('default').startSpan('context-child').end();
       window.testing = false;

--- a/packages/web/integration-tests/tests/context/xhr-events.ejs
+++ b/packages/web/integration-tests/tests/context/xhr-events.ejs
@@ -15,6 +15,10 @@
     btn1.addEventListener('click', function () {
       window.testing = true;
       var req = new XMLHttpRequest();
+
+      // Ensure no error if no listener defined yet
+      req.onload;
+
       req.open('GET', '/some-data');
       req.setRequestHeader('Content-Type', 'text/plain');
       req.send();

--- a/packages/web/src/SplunkContextManager.ts
+++ b/packages/web/src/SplunkContextManager.ts
@@ -398,10 +398,16 @@ export class SplunkContextManager implements ContextManager {
 
     ['onabort', 'onerror', 'onload', 'onloadend', 'onloadstart', 'onprogress', 'ontimeout'].forEach(prop => {
       const desc = Object.getOwnPropertyDescriptor(XMLHttpRequestEventTarget.prototype, prop);
+      if (!desc) {
+        return;
+      }
+
       wrapNatively(desc, 'get', original =>
         function () {
-          const val = original.call(this);
-          if (val._orig) {
+          const val = original!.call(this);
+          // @ts-expect-error we set function._orig bellow
+          if (isFunction(val) && val._orig) {
+            // @ts-expect-error we set function._orig bellow
             return val._orig;
           }
   
@@ -418,7 +424,7 @@ export class SplunkContextManager implements ContextManager {
             value = wrapped;
           }
   
-          return original.call(this, value);
+          return original!.call(this, value);
         }
       );
       Object.defineProperty(XMLHttpRequestEventTarget.prototype, prop, desc);
@@ -447,7 +453,9 @@ export class SplunkContextManager implements ContextManager {
     wrapNatively(desc, 'get', original =>
       function () {
         const val = original.call(this);
-        if (val._orig) {
+        // @ts-expect-error we set function._orig bellow
+        if (isFunction(val) && val._orig) {
+          // @ts-expect-error we set function._orig bellow
           return val._orig;
         }
 
@@ -563,7 +571,9 @@ export class SplunkContextManager implements ContextManager {
     wrapNatively(desc, 'get', original =>
       function () {
         const val = original.call(this);
-        if (val._orig) {
+        // @ts-expect-error we set function._orig bellow
+        if (isFunction(val) && val._orig) {
+          // @ts-expect-error we set function._orig bellow
           return val._orig;
         }
 


### PR DESCRIPTION
# Description

When a patched `on<event>` property is get before an (instrumented) value is set, it can throw when trying to find original function of null value

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- Manual testing
- Added integration tests
