### PR TITLE
config: Make option names align with the GDI spec/the other RUM libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,18 @@ The easiest way to get started is to use Splunk RUM distributed via CDN
     <script src="https://cdn.signalfx.com/o11y-gdi-rum/latest/splunk-otel-web.js" crossorigin="anonymous"></script>
     <script>
       SplunkRum.init({
-          beaconUrl: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
-          rumAuth: 'RUM access token',
-          app: 'enter-your-application-name'
+          beaconEndpoint: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
+          rumAccessToken: 'RUM access token',
+          applicationName: 'enter-your-application-name'
         });
     </script>
     ```
 
 1. Modify the initialization parameters to specify:
-   - `beaconUrl` - the destination URL to which captured telemetry is sent to be ingested. Replace the `<REALM>` with the actual realm you are using (i.e. us0, us1).
-   - `rumAuth` - token authorizing the Agent to send the telemetry to the backend. You can find (or generate) the token [here](https://app.signalfx.com/o11y/#/organization/current?selectedKeyValue=sf_section:accesstokens).
+   - `beaconEndpoint` - the destination URL to which captured telemetry is sent to be ingested. Replace the `<REALM>` with the actual realm you are using (i.e. us0, us1).
+   - `rumAccessToken` - token authorizing the Agent to send the telemetry to the backend. You can find (or generate) the token [here](https://app.signalfx.com/o11y/#/organization/current?selectedKeyValue=sf_section:accesstokens).
      Notice that RUM and APM auth tokens are different.
-   - `app` - naming the application that will be monitored so it can be distinguished from other applications.
+   - `applicationName` - naming the application that will be monitored so it can be distinguished from other applications.
 1. Deploy the changes to your application and make sure that the application is being used.
 
 The method above is the recommendation to get started with Splunk RUM. This approach picks up the latest stable version of the Browser Agent distributed via CDN and loads the agent synchronously.

--- a/docs/Async-Traces.md
+++ b/docs/Async-Traces.md
@@ -35,9 +35,9 @@ As we're currently still testing it you can opt in to using it by setting `conte
 
 ```js
 SplunkRum.init({
-  beaconUrl: 'https://rum-ingest.us0.signalfx.com/v1/rum',
-  rumAuth: 'ABC123...789',
-  app: 'my-awesome-app',
+  beaconEndpoint: 'https://rum-ingest.us0.signalfx.com/v1/rum',
+  rumAccessToken: 'ABC123...789',
+  applicationName: 'my-awesome-app',
   context: {
     async: true,
   },

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -8,11 +8,11 @@ Below are the different initialization options available for the Agent:
 
 |Option|Type|Default value|Description|
 |---|---|---|---|
-|`realm`|`string`| Provided by the guided setup | Your Splunk Observability Cloud realm, for example, `us0` or `us1`. This automatically sets the `beaconUrl` value to the correct rum ingest endpoint of your Splunk Observability Cloud realm. |
-|`beaconUrl`|`string`|Based on `realm`|Sets the destination URL to which captured telemetry is sent to be ingested. If you use `realm` this is automatically set to the correct value based on the realm you've set.|
-|`rumAuth`|`string [required]`|Provided by installation wizard|Defines a token authorizing the Agent to send the telemetry to the backend. You can find (or generate) the token [here](https://app.signalfx.com/o11y/#/organization/current?selectedKeyValue=sf_section:accesstokens). Notice that RUM and APM auth tokens are different.|
-|`app`|`string`|`"unknown-browser-app"`|Application name, used to distinguish the telemetry from different applications.|
-|`environment`|`string`|`(none)`|Sets environment for all the spans, used to distinguish between different environments such as `dev`,  `test` or `prod`. |
+|`realm`|`string`| Provided by the guided setup | Your Splunk Observability Cloud realm, for example, `us0` or `us1`. This automatically sets the `beaconEndpoint` value to the correct rum ingest endpoint of your Splunk Observability Cloud realm. |
+|`beaconEndpoint`|`string`|Based on `realm`|Sets the destination URL to which captured telemetry is sent to be ingested. If you use `realm` this is automatically set to the correct value based on the realm you've set.|
+|`rumAccessToken`|`string [required]`|Provided by installation wizard|Defines a token authorizing the Agent to send the telemetry to the backend. You can find (or generate) the token [here](https://app.signalfx.com/o11y/#/organization/current?selectedKeyValue=sf_section:accesstokens). Notice that RUM and APM auth tokens are different.|
+|`applicationName`|`string`|`"unknown-browser-app"`|Application name, used to distinguish the telemetry from different applications.|
+|`deploymentEnvironment`|`string`|`(none)`|Sets environment for all the spans, used to distinguish between different environments such as `dev`,  `test` or `prod`. |
 |`version`|`string`|`(none)`|Sets app version for all the spans, used to distinguish between different version deployments. For example: `1.0.1` or `20220820` |
 |`globalAttributes`|`object`|`{} empty object`|Sets additional attributes added to all spans (such as version, user id, ...)|
 |`allowInsecureBeacon`|`boolean`|`false`|Allows sending data to insecure endpoints not using `https`. It is not recommended to enable this. |
@@ -61,9 +61,9 @@ In situation, where you need to change the default configuration, you need to ch
 <script>
   window.SplunkRum.init(
     {
-      beaconUrl: 'https://rum-ingest.us0.signalfx.com/v1/rum'
-      rumAuth: 'ABC123...789',
-      app: 'my-awesome-app',
+      beaconEndpoint: 'https://rum-ingest.us0.signalfx.com/v1/rum'
+      rumAccessToken: 'ABC123...789',
+      applicationName: 'my-awesome-app',
       // Any additional options
     });
 </script>
@@ -77,9 +77,9 @@ The following example changes three default configuration parameters:
 
 ```js
 SplunkRum.init({
-  beaconUrl: 'https://rum-ingest.us0.signalfx.com/v1/rum',
-  rumAuth: 'ABC123...789',
-  app: 'my-awesome-app',
+  beaconEndpoint: 'https://rum-ingest.us0.signalfx.com/v1/rum',
+  rumAccessToken: 'ABC123...789',
+  applicationName: 'my-awesome-app',
   instrumentations: {
     interactions: {
       eventNames: [

--- a/docs/ContentSecurityPolicy.md
+++ b/docs/ContentSecurityPolicy.md
@@ -6,4 +6,4 @@ If you're using [Content Security Policy (CSP)](https://developer.mozilla.org/en
 
 - If you use our CDN to load the agent make sure to allow `script-src` `cdn.signalfx.com`
   - Cases of self-hosting and npm installation should already be covered by your site, as otherwise interactivity on your site wouldn't work.
-- Add the host from `beaconUrl` value to `connect-src`, ie. `connect-src` `app.us1.signalfx.com`
+- Add the host from `beaconEndpoint` value to `connect-src`, ie. `connect-src` `app.us1.signalfx.com`

--- a/docs/DataSending.md
+++ b/docs/DataSending.md
@@ -2,7 +2,7 @@
 
 # Data sending
 
-Data is sent to `beaconUrl` in every five seconds using `beacon` or `XHR` depending on each browser's capabilities and limits. 
+Data is sent to `beaconEndpoint` in every five seconds using `beacon` or `XHR` depending on each browser's capabilities and limits. 
 
 ## Limits
 

--- a/docs/Exporters.md
+++ b/docs/Exporters.md
@@ -2,7 +2,7 @@
 
 # Exporters
 
-Splunk's RUM uses Zipkin exporter for sending data to `beaconUrl` endpoint. Other exporters can be registered to the OpenTelemetry provider available on `SplunkRum.provider`:
+Splunk's RUM uses Zipkin exporter for sending data to `beaconEndpoint` endpoint. Other exporters can be registered to the OpenTelemetry provider available on `SplunkRum.provider`:
 
 ```html
 import SplunkRum from '@splunk/otel-js-browser'

--- a/docs/IdentifyingUsers.md
+++ b/docs/IdentifyingUsers.md
@@ -21,9 +21,9 @@ This is useful if you already have this information when the agent is being init
 <script src="https://cdn.signalfx.com/o11y-gdi-rum/latest/splunk-otel-web.js" crossorigin="anonymous"></script>
 <script>
   SplunkRum.init({
-    beaconUrl: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
-    rumAuth: 'RUM access token',
-    app: 'enter-your-application-name',
+    beaconEndpoint: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
+    rumAccessToken: 'RUM access token',
+    applicationName: 'enter-your-application-name',
     globalAttributes: {
       'enduser.id': 42,
       'enduser.role': 'admin',

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -10,18 +10,18 @@ To start monitoring with Splunk RUM distributed via CDN:
     <script src="https://cdn.signalfx.com/o11y-gdi-rum/latest/splunk-otel-web.js" crossorigin="anonymous"></script>
     <script>
       SplunkRum.init({
-          beaconUrl: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
-          rumAuth: 'RUM access token',
-          app: 'enter-your-application-name'
+          beaconEndpoint: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
+          rumAccessToken: 'RUM access token',
+          applicationName: 'enter-your-application-name'
         });
     </script>
     ```
 
 1. Modify the initialization parameters to specify:
-   - `beaconUrl` - the destination URL to which captured telemetry is sent to be ingested. Replace the `<REALM>` with the actual realm you are using (i.e. us0, us1). 
-   - `rumAuth` - token authorizing the Agent to send the telemetry to the backend. You can find (or generate) the token [here](https://app.signalfx.com/o11y/#/organization/current?selectedKeyValue=sf_section:accesstokens). 
+   - `beaconEndpoint` - the destination URL to which captured telemetry is sent to be ingested. Replace the `<REALM>` with the actual realm you are using (i.e. us0, us1). 
+   - `rumAccessToken` - token authorizing the Agent to send the telemetry to the backend. You can find (or generate) the token [here](https://app.signalfx.com/o11y/#/organization/current?selectedKeyValue=sf_section:accesstokens). 
      Notice that RUM and APM auth tokens are different.
-   - `app` - naming the application that will be monitored so it can be distinguished from other applications.
+   - `applicationName` - naming the application that will be monitored so it can be distinguished from other applications.
 1. Deploy the changes to your application and make sure that the application is being used.
 1. Verify that the data is appearing in the RUM dashboard. 
 
@@ -48,17 +48,17 @@ To start monitoring using Splunk RUM distributed via NPM:
     ```html
        import SplunkOtelWeb from '@splunk/otel-web';
        SplunkOtelWeb.init({
-         beaconUrl: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
-         rumAuth: '<RUM access token>',
-         app: '<application-name>',
+         beaconEndpoint: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
+         rumAccessToken: '<RUM access token>',
+         applicationName: '<application-name>',
        });
     ```
 
 1. Modify the initialization parameters to specify:
-   - `beaconUrl` - the destination URL to which captured telemetry is sent to be ingested. Replace the `<REALM>` with the actual realm you are using (i.e. us0, us1). 
-   - `rumAuth` - token authorizing the Agent to send the telemetry to the backend. You can find (or generate) the token [here](https://app.signalfx.com/o11y/#/organization/current?selectedKeyValue=sf_section:accesstokens). 
+   - `beaconEndpoint` - the destination URL to which captured telemetry is sent to be ingested. Replace the `<REALM>` with the actual realm you are using (i.e. us0, us1). 
+   - `rumAccessToken` - token authorizing the Agent to send the telemetry to the backend. You can find (or generate) the token [here](https://app.signalfx.com/o11y/#/organization/current?selectedKeyValue=sf_section:accesstokens). 
      Notice that RUM and APM auth tokens are different.
-   - `app` - naming the application that will be monitored so it can be distinguished from other applications.
+   - `applicationName` - naming the application that will be monitored so it can be distinguished from other applications.
 1. Import or require the file above other application code files in your bundle root ensuring the instrumentation runs before the application code. 
 
 You can find a sample NPM installation in our [Github examples](../examples/installing-npm).

--- a/docs/MigratingInstrumentation.md
+++ b/docs/MigratingInstrumentation.md
@@ -41,8 +41,8 @@ If the relevant properties are known at the time the page is loaded, you can sim
 
 ```js
 SplunkRum.init( {
-    beaconUrl: '...',
-    rumAuth: '...',
+    beaconEndpoint: '...',
+    rumAccessToken: '...',
     globalAttributes: {
         'account.type': goldStatus,
         'app.release': getReleaseNumber(),

--- a/docs/Sampling.md
+++ b/docs/Sampling.md
@@ -19,9 +19,9 @@ These are added to `SplunkRum.*` allowing use on CDN distribution. For example t
   var shouldTrace = isUserLoggedIn();
 
   SplunkRum.init({
-    beaconUrl: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
-    rumAuth: '<RUM access token>',
-    app: '<application-name>',
+    beaconEndpoint: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
+    rumAccessToken: '<RUM access token>',
+    applicationName: '<application-name>',
     tracer: {
       sampler: shouldTrace ? new SplunkRum.AlwaysOnSampler() : new SplunkRum.AlwaysOffSampler(),
     },
@@ -35,9 +35,9 @@ import {AlwaysOnSampler, AlwaysOffSampler} from '@opentelemetry/core';
 import SplunkOtelWeb from '@splunk/otel-web';
 
 SplunkOtelWeb.init({
-  beaconUrl: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
-  rumAuth: '<RUM access token>',
-  app: '<application-name>',
+  beaconEndpoint: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
+  rumAccessToken: '<RUM access token>',
+  applicationName: '<application-name>',
   tracer: {
     sampler: userShouldBeTraced() ? new SplunkRum.AlwaysOnSampler() : new SplunkRum.AlwaysOffSampler(),
   },
@@ -63,9 +63,9 @@ To capture data from half of the sessions:
 <script src="https://cdn.signalfx.com/o11y-gdi-rum/latest/splunk-otel-web.js" crossorigin="anonymous"></script>
 <script>
   SplunkRum.init({
-    beaconUrl: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
-    rumAuth: '<RUM access token>',
-    app: '<application-name>',
+    beaconEndpoint: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
+    rumAccessToken: '<RUM access token>',
+    applicationName: '<application-name>',
     tracer: {
       sampler: new SplunkRum.SessionBasedSampler({
         ratio: 0.5
@@ -80,9 +80,9 @@ To capture data from half of the sessions:
 import SplunkOtelWeb, {SessionBasedSampler} from '@splunk/otel-web';
 
 SplunkOtelWeb.init({
-  beaconUrl: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
-  rumAuth: '<RUM access token>',
-  app: '<application-name>',
+  beaconEndpoint: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
+  rumAccessToken: '<RUM access token>',
+  applicationName: '<application-name>',
   tracer: {
     sampler: new SessionBasedSampler({
       ratio: 0.5

--- a/examples/installing-npm/README.md
+++ b/examples/installing-npm/README.md
@@ -8,12 +8,12 @@ Run `npm start` to start the example app (requires another shell tab/instance).
 Open <http://localhost:9100/> to open the app and start producing telemetry data.
 
 ## Sending the data to Splunk Real User Monitoring <a name="backend-config"></a>
-Add `rumAuthToken` and change `beaconUrl` in the instrumentation initialisation object:
+Add `rumAccessToken` and change `beaconEndpoint` in the instrumentation initialisation object:
 ```js
 SplunkOtelWeb.init({
   ...
-  beaconUrl: 'https://rum-ingest.signalfx.com/api/v2/spans',
-  rumAuthToken: 'xxx', // TODO: describe how to get the token
+  beaconEndpoint: 'https://rum-ingest.us0.signalfx.com/api/v2/spans',
+  rumAccessToken: 'xxx', // TODO: describe how to get the token
   ...
 });
 ```
@@ -33,9 +33,9 @@ import SplunkOtelWeb from '@splunk/otel-web';
 
 SplunkOtelWeb.init({
   // we will provision a temporary local backend for testing in a few steps
-  beaconUrl: 'http://localhost:9411/api/v2/spans',
+  beaconEndpoint: 'http://localhost:9411/api/v2/spans',
   allowInsecureBeacon: true,
-  app: 'splunk-otel-web-example-npm',
+  applicationName: 'splunk-otel-web-example-npm',
 });
 ```
 

--- a/examples/installing-npm/src/instrumentation.js
+++ b/examples/installing-npm/src/instrumentation.js
@@ -1,14 +1,14 @@
 import SplunkOtelWeb from '@splunk/otel-web';
 
 SplunkOtelWeb.init({
-  beaconUrl: 'http://localhost:9101/api/v2/spans',
+  beaconEndpoint: 'http://localhost:9101/api/v2/spans',
   debug: true,
   allowInsecureBeacon: true,
-  app: 'splunk-otel-web-example-npm',
+  applicationName: 'splunk-otel-web-example-npm',
 
   // uncomment to start sending to Splunk RUM backend
-  // beaconUrl: 'https://rum-ingest.signalfx.com/api/v2/spans',
+  // beaconEndpoint: 'https://rum-ingest.signalfx.com/api/v2/spans',
   
   // get the token by going to https://app.signalfx.com/#/organization/current?selectedKeyValue=sf_section:accesstokens
-  rumAuth: 'ABC123...789',
+  rumAccessToken: 'ABC123...789',
 });

--- a/examples/next-ssr-example/src/instrument.js
+++ b/examples/next-ssr-example/src/instrument.js
@@ -2,8 +2,8 @@
 import SplunkOtelWeb from '@splunk/otel-web';
 
 SplunkOtelWeb.init({
-  beaconUrl: process.env.NEXT_PUBLIC_SPLUNK_RUM_BEACON_URL,
-  rumAuth: process.env.NEXT_PUBLIC_SPLUNK_RUM_AUTH,
-  app: process.env.NEXT_PUBLIC_SPLUNK_RUM_APP,
-  env: process.env.NEXT_PUBLIC_SPLUNK_RUM_ENV,
+  beaconEndpoint: process.env.NEXT_PUBLIC_SPLUNK_RUM_BEACON_URL,
+  rumAccessToken: process.env.NEXT_PUBLIC_SPLUNK_RUM_AUTH,
+  applicationName: process.env.NEXT_PUBLIC_SPLUNK_RUM_APP,
+  deploymentEnvironment: process.env.NEXT_PUBLIC_SPLUNK_RUM_ENV,
 });

--- a/examples/todolist/public/index.html
+++ b/examples/todolist/public/index.html
@@ -33,9 +33,9 @@
     <script>
       SplunkRum.init({
         // Values here are injected from .env file by create-react-app
-        beaconUrl: '%REACT_APP_RUM_BEACON_URL%',
-        rumAuth: '%REACT_APP_RUM_TOKEN%',
-        app: 'enter-your-application-name',
+        beaconEndpoint: '%REACT_APP_RUM_BEACON_URL%',
+        rumAccessToken: '%REACT_APP_RUM_TOKEN%',
+        applicationName: 'enter-your-application-name',
         allowInsecureBeacon: true,
         // Ignore /ping request that is on a 30s interval
         ignoreUrls: [/\/ping/],

--- a/packages/session-recorder/README.md
+++ b/packages/session-recorder/README.md
@@ -30,7 +30,7 @@ import SplunkSessionRecorder from '@splunk/otel-web-session-recorder'
 
 // This must be called after initializing splunk rum
 SplunkSessionRecorder.init({
-  beaconUrl: 'https://rum-ingest.<realm>.signalfx.com/v1/rumreplay',
-  rumAuth: '<auth token>'
+  beaconEndpoint: 'https://rum-ingest.<realm>.signalfx.com/v1/rumreplay',
+  rumAccessToken: '<auth token>'
 });
 ```

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -31,18 +31,18 @@ The easiest way to get started is to use Splunk RUM distributed via CDN
     <script src="https://cdn.signalfx.com/o11y-gdi-rum/latest/splunk-otel-web.js" crossorigin="anonymous"></script>
     <script>
       SplunkRum.init({
-          beaconUrl: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
-          rumAuth: 'RUM access token',
-          app: 'enter-your-application-name'
+          beaconEndpoint: 'https://rum-ingest.<REALM>.signalfx.com/v1/rum',
+          rumAccessToken: 'RUM access token',
+          applicationName: 'enter-your-application-name'
         });
     </script>
     ```
 
 1. Modify the initialization parameters to specify:
-   - `beaconUrl` - the destination URL to which captured telemetry is sent to be ingested. Replace the `<REALM>` with the actual realm you are using (i.e. us0, us1).
-   - `rumAuth` - token authorizing the Agent to send the telemetry to the backend. You can find (or generate) the token [here](https://app.signalfx.com/o11y/#/organization/current?selectedKeyValue=sf_section:accesstokens).
+   - `beaconEndpoint` - the destination URL to which captured telemetry is sent to be ingested. Replace the `<REALM>` with the actual realm you are using (i.e. us0, us1).
+   - `rumAccessToken` - token authorizing the Agent to send the telemetry to the backend. You can find (or generate) the token [here](https://app.signalfx.com/o11y/#/organization/current?selectedKeyValue=sf_section:accesstokens).
      Notice that RUM and APM auth tokens are different.
-   - `app` - naming the application that will be monitored so it can be distinguished from other applications.
+   - `applicationName` - naming the application that will be monitored so it can be distinguished from other applications.
 1. Deploy the changes to your application and make sure that the application is being used.
 
 The method above is the recommendation to get started with Splunk RUM. This approach picks up the latest stable version of the Browser Agent distributed via CDN and loads the agent synchronously.

--- a/packages/web/integration-tests/tests/cdn/index.ejs
+++ b/packages/web/integration-tests/tests/cdn/index.ejs
@@ -4,7 +4,14 @@
 	<meta charset="UTF-8">
 	<title>CDN test with an unhandled error</title>
 
-	<%- renderAgent({}, false, null, 'latest' ) %>
+	<%- renderAgent({}, true, null, 'latest' ) %>
+  <script>
+    // CHANGEME: Postrelease 0.16: Go back to auto init (true -> false above) and delete this
+    SplunkRumOptions.app = SplunkRumOptions.applicationName;
+    SplunkRumOptions.beaconUrl = SplunkRumOptions.beaconEndpoint;
+    SplunkRum.init(SplunkRumOptions);
+  </script>
+
   <script id="scenario">
     var test = null;
     setTimeout(() => {

--- a/packages/web/integration-tests/tests/cookies/iframe.ejs
+++ b/packages/web/integration-tests/tests/cookies/iframe.ejs
@@ -4,7 +4,7 @@
 	<meta charset="UTF-8">
 	<title>Iframe</title>
 
-	<%- renderAgent({app: 'iframe'}) %>
+	<%- renderAgent({applicationName: 'iframe'}) %>
 </head>
 <body>
 	<h1>IFRAME</h1>

--- a/packages/web/integration-tests/tests/init/attributes-no-globals.ejs
+++ b/packages/web/integration-tests/tests/init/attributes-no-globals.ejs
@@ -4,7 +4,7 @@
 	<meta charset="UTF-8">
 	<title>Test init</title>
 
-	<%- renderAgent({app:'custom-app', environment: 'custom-environment'}) %>
+	<%- renderAgent({applicationName:'custom-app', deploymentEnvironment: 'custom-environment'}) %>
 </head>
 <body>
 	<p>Attributes</p>

--- a/packages/web/integration-tests/tests/init/attributes.ejs
+++ b/packages/web/integration-tests/tests/init/attributes.ejs
@@ -4,7 +4,7 @@
 	<meta charset="UTF-8">
 	<title>Test init</title>
 
-	<%- renderAgent({app:'custom-app', environment: 'custom-environment', globalAttributes: {'key1': 'value1', 'key2': 'value2'}}) %>
+	<%- renderAgent({applicationName:'custom-app', deploymentEnvironment: 'custom-environment', globalAttributes: {'key1': 'value1', 'key2': 'value2'}}) %>
 </head>
 <body>
 	<p>Attributes</p>

--- a/packages/web/integration-tests/tests/init/nobeacon.ejs
+++ b/packages/web/integration-tests/tests/init/nobeacon.ejs
@@ -4,7 +4,7 @@
 	<meta charset="UTF-8">
 	<title>Test init</title>
 
-	<%- renderAgent({beaconUrl: undefined}) %>
+	<%- renderAgent({beaconEndpoint: undefined}) %>
 </head>
 <body>
 	<p>Init</p>

--- a/packages/web/performance-tests/devServer/devServer.js
+++ b/packages/web/performance-tests/devServer/devServer.js
@@ -18,7 +18,7 @@ const path = require('path');
 const express = require('express');
 const bodyParser = require('body-parser');
 const WebSocket = require('ws');
-const {renderFile} = require('ejs');
+const { renderFile } = require('ejs');
 const {
   handleReactBundleRequest,
   generateReactBundleTags,
@@ -35,11 +35,11 @@ const {
 } = require('../../test-utils/server/index');
 const { generateServerTiming, setServerTimingHeader } = require('../../test-utils/server/serverTiming');
 
-function getRumScript({beaconHost, beaconPort}) {
+function getRumScript({ beaconHost, beaconPort }) {
   return `
     <script src="https://${beaconHost}:${beaconPort}/dist/splunk-otel-web.js"></script>
     <script>
-      SplunkRum.init({"beaconUrl":"https://${beaconHost}:${beaconPort}/api/v2/spans", app:"perf-test-app", debug:true});
+      SplunkRum.init({"beaconEndpoint":"https://${beaconHost}:${beaconPort}/api/v2/spans", applicationName:"perf-test-app", debug:true});
     </script>
   `;
 }
@@ -80,12 +80,12 @@ function getSpans(spanOrSpans) {
   }];
 }
 
-async function run({onSpanReceived, enableHttps, port}) {
+async function run({ onSpanReceived, enableHttps, port }) {
   enableHttps = enableHttps || false;
   let lastServerTiming;
   function addHeaders(response) {
     lastServerTiming = generateServerTiming();
-    setServerTimingHeader(response, lastServerTiming)
+    setServerTimingHeader(response, lastServerTiming);
   }
 
   if (!onSpanReceived) {
@@ -174,7 +174,7 @@ async function run({onSpanReceived, enableHttps, port}) {
     websocketsPort: wsPort,
     getLastServerTiming: () => lastServerTiming,
   };
-};
+}
 
 module.exports = {
   run,

--- a/packages/web/performance-tests/devServer/index.html
+++ b/packages/web/performance-tests/devServer/index.html
@@ -3,8 +3,8 @@
   <script src="/dist/splunk-otel-web.js"></script>
   <script>
     window.SplunkRum && window.SplunkRum.init({ 
-      beaconUrl: '/api/v2/spans', 
-      app: 'splunk-otel-js-dummy-app',
+      beaconEndpoint: '/api/v2/spans', 
+      applicationName: 'splunk-otel-js-dummy-app',
       debug: true
     });
   </script>

--- a/packages/web/performance-tests/devServer/splunkRumProvider.js
+++ b/packages/web/performance-tests/devServer/splunkRumProvider.js
@@ -1,6 +1,22 @@
+/*
+Copyright 2023 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 const path = require('path');
 const fs = require('fs');
-const {render} = require('ejs');
+const { render } = require('ejs');
 
 const SPLUNK_RUM_TAGS_TEMPLATE = `
 <script src="<%= file -%>"></script>
@@ -23,8 +39,8 @@ async function handleSplunkRumRequest(app) {
 
 function generateSplunkRumTags () {
   const options = {
-    beaconUrl: `/api/v2/spans`,
-    app: 'splunk-otel-js-dummy-app',
+    beaconEndpoint: '/api/v2/spans',
+    applicationName: 'splunk-otel-js-dummy-app',
     debug: false,
   };
 

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -441,7 +441,7 @@ export const SplunkRum: SplunkOtelWebType = {
     }).filter((a): a is Exclude<typeof a, null> => Boolean(a));
 
     this.attributesProcessor = new SplunkSpanAttributesProcessor({
-      ...deploymentEnvironment ? { environment: deploymentEnvironment } : {},
+      ...deploymentEnvironment ? { environment: deploymentEnvironment, 'deployment.environment': deploymentEnvironment } : {},
       ...version ? { 'app.version': version } : {},
       ...processedOptions.globalAttributes || {},
     });

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -99,11 +99,22 @@ export interface SplunkOtelWebConfig {
   /** Allows http beacon urls */
   allowInsecureBeacon?: boolean;
 
+  /** Application name
+   * @deprecated Renamed to `applicationName`
+   */
+  app?: string;
+
   /** Application name */
-  app: string;
+  applicationName?: string;
+
+  /**
+   * Destination for the captured data
+   * @deprecated Renamed to `beaconEndpoint`, or use realm
+   */
+  beaconUrl?: string;
 
   /** Destination for the captured data */
-  beaconUrl?: string;
+  beaconEndpoint?: string;
 
   /** Options for context manager */
   context?: ContextManagerConfig;
@@ -117,6 +128,12 @@ export interface SplunkOtelWebConfig {
   /**
    * Sets a value for the `environment` attribute (persists through calls to `setGlobalAttributes()`)
    * */
+  deploymentEnvironment?: string;
+
+  /**
+   * Sets a value for the `environment` attribute (persists through calls to `setGlobalAttributes()`)
+   * @deprecated Renamed to `deploymentEnvironment`
+   */
   environment?: string;
 
   /**
@@ -128,9 +145,7 @@ export interface SplunkOtelWebConfig {
   exporter?: SplunkOtelWebExporterOptions;
 
   /** Sets attributes added to every Span. */
-  globalAttributes?: {
-    [attributeKey: string]: string;
-  };
+  globalAttributes?: Attributes;
 
   /**
    * Applies for XHR, Fetch and Websocket URLs. URLs that partially match any regex in ignoreUrls will not be traced.
@@ -149,8 +164,15 @@ export interface SplunkOtelWebConfig {
   /**
    * Publicly-visible `rumAuth` value.  Please do not paste any other access token or auth value into here, as this
    * will be visible to every user of your app
-   * */
-  rumAuth: string | undefined;
+   * @deprecated Renamed to rumAccessToken
+   */
+  rumAuth?: string;
+
+  /**
+   * Publicly-visible rum access token value. Please do not paste any other access token or auth value into here, as this
+   * will be visible to every user of your app
+   */
+  rumAccessToken?: string;
 
   /**
    * Config options passed to web tracer
@@ -174,8 +196,8 @@ interface SplunkOtelWebConfigInternal extends SplunkOtelWebConfig {
 }
 
 const OPTIONS_DEFAULTS: SplunkOtelWebConfigInternal = {
-  app: 'unknown-browser-app',
-  beaconUrl: undefined,
+  applicationName: 'unknown-browser-app',
+  beaconEndpoint: undefined,
   bufferTimeout: 4000, //millis, tradeoff between batching and loss of spans by not sending before page close
   bufferSize: 50, // spans, tradeoff between batching and hitting sendBeacon invididual limits
   instrumentations: {},
@@ -185,8 +207,26 @@ const OPTIONS_DEFAULTS: SplunkOtelWebConfigInternal = {
   spanProcessor: {
     factory: (exporter, config) => new BatchSpanProcessor(exporter, config),
   },
-  rumAuth: undefined,
+  rumAccessToken: undefined,
 };
+
+function migrateConfigOption(config: SplunkOtelWebConfig, from: keyof SplunkOtelWebConfig, to: keyof SplunkOtelWebConfig) {
+  if (from in config && !(to in config && config[to] !== OPTIONS_DEFAULTS[to])) {
+    // @ts-expect-error There's no way to type this right
+    config[to] = config[from];
+  }
+}
+
+/**
+ * Update configuration based on configuration option renames
+ */
+function migrateConfig(config: SplunkOtelWebConfig) {
+  migrateConfigOption(config, 'app', 'applicationName');
+  migrateConfigOption(config, 'beaconUrl', 'beaconEndpoint');
+  migrateConfigOption(config, 'environment', 'deploymentEnvironment');
+  migrateConfigOption(config, 'rumAuth', 'rumAccessToken');
+  return config;
+}
 
 const INSTRUMENTATIONS = [
   { Instrument: SplunkDocumentLoadInstrumentation, confKey: 'document', disable: false },
@@ -209,10 +249,10 @@ export const INSTRUMENTATIONS_ALL_DISABLED: SplunkOtelWebOptionsInstrumentations
     { 'webvitals': false },
   );
 
-function buildExporter(options) {
-  const completeUrl = options.beaconUrl + (options.rumAuth ? '?auth='+options.rumAuth : '');
+function buildExporter(options: SplunkOtelWebConfigInternal) {
+  const beaconUrl = options.beaconEndpoint + (options.rumAccessToken ? '?auth='+options.rumAccessToken : '');
   return options.exporter.factory({
-    beaconUrl: completeUrl,
+    beaconUrl,
     onAttributesSerializing: options.exporter.onAttributesSerializing,
   });
 }
@@ -313,7 +353,7 @@ export const SplunkRum: SplunkOtelWebType = {
     const processedOptions: SplunkOtelWebConfigInternal = Object.assign(
       {},
       OPTIONS_DEFAULTS,
-      options,
+      migrateConfig(options),
       {
         exporter: Object.assign({}, OPTIONS_DEFAULTS.exporter, options.exporter),
       },
@@ -325,21 +365,21 @@ export const SplunkRum: SplunkOtelWebType = {
     }
 
     if (processedOptions.realm) {
-      if (!processedOptions.beaconUrl) {
-        processedOptions.beaconUrl = `https://rum-ingest.${processedOptions.realm}.signalfx.com/v1/rum`;
+      if (!processedOptions.beaconEndpoint) {
+        processedOptions.beaconEndpoint = `https://rum-ingest.${processedOptions.realm}.signalfx.com/v1/rum`;
       } else {
-        diag.warn('SplunkRum: Realm value ignored (beaconURL has been specified)');
+        diag.warn('SplunkRum: Realm value ignored (beaconEndpoint has been specified)');
       }
     }
 
     if (!processedOptions.debug) {
-      if (!processedOptions.beaconUrl) {
-        throw new Error('SplunkRum.init( {beaconUrl: \'https://something\'} ) is required.');
-      } else if(!processedOptions.beaconUrl.startsWith('https') && !processedOptions.allowInsecureBeacon) {
+      if (!processedOptions.beaconEndpoint) {
+        throw new Error('SplunkRum.init( {beaconEndpoint: \'https://something\'} ) is required.');
+      } else if(!processedOptions.beaconEndpoint.startsWith('https') && !processedOptions.allowInsecureBeacon) {
         throw new Error('Not using https is unsafe, if you want to force it use allowInsecureBeacon option.');
       }
-      if (!processedOptions.rumAuth) {
-        diag.warn('rumAuth will be required in the future');
+      if (!processedOptions.rumAccessToken) {
+        diag.warn('rumAccessToken will be required in the future');
       }
     }
 
@@ -350,7 +390,7 @@ export const SplunkRum: SplunkOtelWebType = {
       processedOptions.cookieDomain,
     ).deinit;
 
-    const { ignoreUrls, app, environment, version } = processedOptions;
+    const { ignoreUrls, applicationName, deploymentEnvironment, version } = processedOptions;
     // enabled: false prevents registerInstrumentations from enabling instrumentations in constructor
     // they will be enabled in registerInstrumentations
     const pluginDefaults = { ignoreUrls, enabled: false };
@@ -362,7 +402,7 @@ export const SplunkRum: SplunkOtelWebType = {
       // Splunk specific attributes
       'splunk.rumVersion': VERSION,
       'splunk.scriptInstance': instanceId,
-      'app': app,
+      'app': applicationName,
     };
 
     const syntheticsRunId = getSyntheticsRunId();
@@ -401,13 +441,13 @@ export const SplunkRum: SplunkOtelWebType = {
     }).filter((a): a is Exclude<typeof a, null> => Boolean(a));
 
     this.attributesProcessor = new SplunkSpanAttributesProcessor({
-      ...environment ? { environment } : {},
+      ...deploymentEnvironment ? { environment: deploymentEnvironment } : {},
       ...version ? { 'app.version': version } : {},
       ...processedOptions.globalAttributes || {},
     });
     provider.addSpanProcessor(this.attributesProcessor);
 
-    if (processedOptions.beaconUrl) {
+    if (processedOptions.beaconEndpoint) {
       const exporter = buildExporter(processedOptions);
       const spanProcessor = processedOptions.spanProcessor.factory(exporter, {
         scheduledDelayMillis: processedOptions.bufferTimeout,

--- a/packages/web/test/SplunkContextManager.test.ts
+++ b/packages/web/test/SplunkContextManager.test.ts
@@ -24,9 +24,9 @@ describe('async context propagation', () => {
   const capturer = new SpanCapturer();
   beforeEach(() => {
     SplunkOtelWeb.init({
-      app: 'my-app',
-      beaconUrl: 'https://localhost:9411/api/traces',
-      rumAuth: 'xxx',
+      applicationName: 'my-app',
+      beaconEndpoint: 'https://localhost:9411/api/traces',
+      rumAccessToken: 'xxx',
       context: {
         async: true,
       },

--- a/packages/web/test/SplunkOtelWeb.test.ts
+++ b/packages/web/test/SplunkOtelWeb.test.ts
@@ -27,9 +27,9 @@ describe('SplunkOtelWeb', () => {
   describe('global attributes', () => {
     it('should be settable via constructor and then readable', () => {
       SplunkRum.init({
-        app: 'app-name',
-        beaconUrl: 'https://beacon',
-        rumAuth: '<token>',
+        applicationName: 'app-name',
+        beaconEndpoint: 'https://beacon',
+        rumAccessToken: '<token>',
         globalAttributes: {
           key1: 'value1',
         },
@@ -41,9 +41,9 @@ describe('SplunkOtelWeb', () => {
 
     it('should be patchable via setGlobalAttributes and then readable', () => {
       SplunkRum.init({
-        app: 'app-name',
-        beaconUrl: 'https://beacon',
-        rumAuth: '<token>',
+        applicationName: 'app-name',
+        beaconEndpoint: 'https://beacon',
+        rumAccessToken: '<token>',
         globalAttributes: {
           key1: 'value1',
           key2: 'value2',
@@ -64,9 +64,9 @@ describe('SplunkOtelWeb', () => {
 
     it('should notify about changes via setGlobalAttributes', async () => {
       SplunkRum.init({
-        app: 'app-name',
-        beaconUrl: 'https://beacon',
-        rumAuth: '<token>',
+        applicationName: 'app-name',
+        beaconEndpoint: 'https://beacon',
+        rumAccessToken: '<token>',
         globalAttributes: {
           key1: 'value1',
           key2: 'value2',
@@ -102,9 +102,9 @@ describe('SplunkOtelWeb', () => {
       expect(SplunkRum.getSessionId()).to.eq(undefined);
 
       SplunkRum.init({
-        app: 'app-name',
-        beaconUrl: 'https://beacon',
-        rumAuth: '<token>'
+        applicationName: 'app-name',
+        beaconEndpoint: 'https://beacon',
+        rumAccessToken: '<token>'
       });
       expect(SplunkRum.getSessionId()).to.match(/[0-9a-f]{32}/);
 
@@ -116,9 +116,9 @@ describe('SplunkOtelWeb', () => {
       let sessionId: string | undefined;
 
       SplunkRum.init({
-        app: 'app-name',
-        beaconUrl: 'https://beacon',
-        rumAuth: '<token>'
+        applicationName: 'app-name',
+        beaconEndpoint: 'https://beacon',
+        rumAccessToken: '<token>'
       });
       SplunkRum.addEventListener(
         'session-changed',
@@ -140,9 +140,9 @@ describe('SplunkOtelWeb', () => {
       expect(SplunkRum.inited).to.eq(false, 'Should be false in the beginning.');
 
       SplunkRum.init({
-        app: 'app-name',
-        beaconUrl: 'https://beacon',
-        rumAuth: '<token>'
+        applicationName: 'app-name',
+        beaconEndpoint: 'https://beacon',
+        rumAccessToken: '<token>'
       });
       expect(SplunkRum.inited).to.eq(true, 'Should be true after creating.');
 

--- a/packages/web/test/api.test.ts
+++ b/packages/web/test/api.test.ts
@@ -27,9 +27,9 @@ describe('Transitive API', () => {
 
   beforeEach(() => {
     SplunkOtelWeb.init({
-      app: 'my-app',
-      beaconUrl: 'https://localhost:9411/api/traces',
-      rumAuth: 'xxx',
+      applicationName: 'my-app',
+      beaconEndpoint: 'https://localhost:9411/api/traces',
+      rumAccessToken: 'xxx',
       instrumentations: INSTRUMENTATIONS_ALL_DISABLED,
     });
 

--- a/packages/web/test/init.test.ts
+++ b/packages/web/test/init.test.ts
@@ -47,7 +47,7 @@ describe('test init', () => {
   describe('should enforce secure beacon url', () => {
     it('should not be inited with http', () => {
       try {
-        SplunkRum.init({ beaconUrl: 'http://127.0.0.1:8888/insecure', app: 'app', rumAuth: undefined });
+        SplunkRum.init({ beaconEndpoint: 'http://127.0.0.1:8888/insecure', applicationName: 'app', rumAccessToken: undefined });
         assert.ok(false);
       } catch(e) {
         assert.ok(SplunkRum.inited === false);
@@ -57,7 +57,7 @@ describe('test init', () => {
     });
     it('should init with https', () => {
       const path = '/secure';
-      SplunkRum.init({ beaconUrl: `https://127.0.0.1:8888/${path}`, app: 'app', rumAuth: undefined });
+      SplunkRum.init({ beaconEndpoint: `https://127.0.0.1:8888/${path}`, applicationName: 'app', rumAccessToken: undefined });
       assert.ok(SplunkRum.inited);
       doesBeaconUrlEndWith(path);
       SplunkRum.deinit();
@@ -65,10 +65,10 @@ describe('test init', () => {
     it('can be forced via allowInsecureBeacon option', () => {
       const path = '/insecure';
       SplunkRum.init({
-        beaconUrl: `http://127.0.0.1:8888/${path}`,
+        beaconEndpoint: `http://127.0.0.1:8888/${path}`,
         allowInsecureBeacon: true,
-        app: 'app',
-        rumAuth: undefined,
+        applicationName: 'app',
+        rumAccessToken: undefined,
       });
       assert.ok(SplunkRum.inited);
       doesBeaconUrlEndWith(path);
@@ -77,8 +77,8 @@ describe('test init', () => {
     it('can use realm config option', () => {
       SplunkRum.init({
         realm: 'test',
-        app: 'app',
-        rumAuth: undefined,
+        applicationName: 'app',
+        rumAccessToken: undefined,
       });
       assert.ok(SplunkRum.inited);
       doesBeaconUrlEndWith('https://rum-ingest.test.signalfx.com/v1/rum');
@@ -139,8 +139,8 @@ describe('test init', () => {
   });
   describe('double-init has no effect', () => {
     it('should have been inited only once', () => {
-      SplunkRum.init({ beaconUrl: 'https://127.0.0.1:8888/foo', app: 'app', rumAuth: undefined });
-      SplunkRum.init({ beaconUrl: 'https://127.0.0.1:8888/bar', app: 'app', rumAuth: undefined });
+      SplunkRum.init({ beaconEndpoint: 'https://127.0.0.1:8888/foo', applicationName: 'app', rumAccessToken: undefined });
+      SplunkRum.init({ beaconEndpoint: 'https://127.0.0.1:8888/bar', applicationName: 'app', rumAccessToken: undefined });
       doesBeaconUrlEndWith('/foo');
       SplunkRum.deinit();
     });
@@ -150,10 +150,10 @@ describe('test init', () => {
       const exportMock = sinon.fake();
       const onAttributesSerializingMock = sinon.fake();
       SplunkRum._internalInit({
-        beaconUrl: 'https://domain1',
+        beaconEndpoint: 'https://domain1',
         allowInsecureBeacon: true,
-        app: 'my-app',
-        environment: 'my-env',
+        applicationName: 'my-app',
+        deploymentEnvironment: 'my-env',
         globalAttributes: { customerType: 'GOLD' },
         bufferTimeout: 0,
         exporter: {
@@ -166,7 +166,7 @@ describe('test init', () => {
             };
           },
         },
-        rumAuth: '123-no-warn-spam-in-console',
+        rumAccessToken: '123-no-warn-spam-in-console',
       });
       SplunkRum.provider.getTracer('test').startSpan('testSpan').end();
       setTimeout(() => {

--- a/packages/web/test/nodejs.test.ts
+++ b/packages/web/test/nodejs.test.ts
@@ -20,9 +20,9 @@ import SplunkRum from '../src/index';
 describe('Node.js basic support', () => {
   it('Can call init', () => {
     SplunkRum.init({
-      app: 'test-app',
-      beaconUrl: 'https://localhost/events',
-      rumAuth: 'example1234'
+      applicationName: 'test-app',
+      beaconEndpoint: 'https://localhost/events',
+      rumAccessToken: 'example1234'
     });
   });
 

--- a/packages/web/test/utils.ts
+++ b/packages/web/test/utils.ts
@@ -54,14 +54,14 @@ export function buildInMemorySplunkExporter(): {
 
 export function initWithDefaultConfig(capturer: SpanCapturer, additionalOptions = {}): void {
   SplunkRum._internalInit({
-    beaconUrl: 'http://127.0.0.1:8888/v1/trace',
+    beaconEndpoint: 'http://127.0.0.1:8888/v1/trace',
     allowInsecureBeacon: true,
-    app: 'my-app',
-    environment: 'my-env',
+    applicationName: 'my-app',
+    deploymentEnvironment: 'my-env',
     version: '1.2-test.3',
     globalAttributes: { customerType: 'GOLD' },
     bufferTimeout: 0,
-    rumAuth: '123-no-warn-spam-in-console',
+    rumAccessToken: '123-no-warn-spam-in-console',
     ...additionalOptions,
   });
   SplunkRum.provider.addSpanProcessor(capturer);
@@ -75,13 +75,13 @@ export function initWithSyncPipeline(additionalOptions = {}): {
   const processor = new SimpleSpanProcessor(exporter);
 
   SplunkRum._internalInit({
-    beaconUrl: 'http://127.0.0.1:8888/v1/trace',
+    beaconEndpoint: 'http://127.0.0.1:8888/v1/trace',
     allowInsecureBeacon: true,
-    app: 'my-app',
-    environment: 'my-env',
+    applicationName: 'my-app',
+    deploymentEnvironment: 'my-env',
     version: '1.2-test.3',
     bufferTimeout: 0,
-    rumAuth: '123-no-warn-spam-in-console',
+    rumAccessToken: '123-no-warn-spam-in-console',
     exporter: { factory: () => exporter },
     spanProcessor: { factory: () => processor },
     ...additionalOptions,

--- a/packages/web/test/utils.ts
+++ b/packages/web/test/utils.ts
@@ -61,7 +61,7 @@ export function initWithDefaultConfig(capturer: SpanCapturer, additionalOptions 
     version: '1.2-test.3',
     globalAttributes: { customerType: 'GOLD' },
     bufferTimeout: 0,
-    rumAuth: undefined,
+    rumAuth: '123-no-warn-spam-in-console',
     ...additionalOptions,
   });
   SplunkRum.provider.addSpanProcessor(capturer);
@@ -81,7 +81,7 @@ export function initWithSyncPipeline(additionalOptions = {}): {
     environment: 'my-env',
     version: '1.2-test.3',
     bufferTimeout: 0,
-    rumAuth: undefined,
+    rumAuth: '123-no-warn-spam-in-console',
     exporter: { factory: () => exporter },
     spanProcessor: { factory: () => processor },
     ...additionalOptions,

--- a/packages/web/utils/devServer/index.html
+++ b/packages/web/utils/devServer/index.html
@@ -21,8 +21,8 @@
   <script src="/dist/artifacts/splunk-otel-web.js"></script>
   <script>
     window.SplunkRum && window.SplunkRum.init({
-      beaconUrl: '/api/v2/spans',
-      app: 'splunk-otel-js-dummy-app',
+      beaconEndpoint: '/api/v2/spans',
+      applicationName: 'splunk-otel-js-dummy-app',
       debug: true
     });
   </script>

--- a/packages/web/utils/devServer/templateProvider.js
+++ b/packages/web/utils/devServer/templateProvider.js
@@ -95,8 +95,8 @@ exports.registerTemplateProvider = ({ app, addHeaders, enableHttps }) => {
         httpPort: app.get('httpPort'),
         renderAgent(userOpts = {}, noInit = false, file = defaultFile, cdnVersion = null) {
           const options = {
-            beaconUrl: beaconUrl.toString(),
-            app: 'splunk-otel-js-dummy-app',
+            beaconEndpoint: beaconUrl.toString(),
+            applicationName: 'splunk-otel-js-dummy-app',
             debug: true,
             bufferTimeout: require('../../integration-tests/utils/globals').GLOBAL_TEST_BUFFER_TIMEOUT,
             ...userOpts


### PR DESCRIPTION
# Description

Renamed config options to follow [GDI spec](https://github.com/signalfx/gdi-specification/blob/v1.5.0/specification/configuration.md#real-user-monitoring-libraries)

Old | New
-- | --
`beaconUrl` | `beaconEndpoint`
`rumAuth` | `rumAccessToken`
`app` | `applicationName`
`environment` | `deploymentEnvironment`

All of these changes are backwards compatible - users still using the old keys can continue to use them, even if the rum library gets updated via cdn's `/latest/`

Changes to code & test for aliasing have been rolled up to one commit: https://github.com/signalfx/splunk-otel-js-web/commit/d73631478ec11dccffe599eca7d00971b540f836

Search&Replace on internal docs: https://github.com/signalfx/splunk-otel-js-web/commit/26e08e5cd9d2bb71847e762f2a212ddd1c88d3df

(@theletterf We definitely should wait until this has been released before updating public docs / installation wiz since using the new keys with older version doesn't work)

Rest of the commits update current tests to use the new keys

## Type of change

- Alignment to GDI Spec in preperation of stable release
- Chore or internal change (changes not _immediately_ visible to the consumers of the package)
- Documentation update

# How has this been tested?

- Manual testing
- Updated unit tests
- Updated integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
