### PR TITLE
Filter inaccurate CORS timings in case of more precise timeOrigin

### DIFF
--- a/packages/web/src/SplunkExporter.ts
+++ b/packages/web/src/SplunkExporter.ts
@@ -189,7 +189,9 @@ export class SplunkExporter implements SpanExporter {
     const zero = performance.timeOrigin * 1000;
     if (span.tags['http.url'] && !(span.tags['http.url'] as string).startsWith(location.origin) && span.timestamp > zero && span.annotations) {
       span.annotations = span.annotations.filter(({ timestamp }) => {
-        return timestamp !== zero;
+        // Chrome has increased precision on timeOrigin but otel may round it
+        // Due to multiple roundings and truncs it can be less than timeOrigin
+        return timestamp > zero;
       });
     }
     return span;


### PR DESCRIPTION
# Description

Chrome can now have more precise `performance.timeOrigin` than just int timestamp, but due to multiple layers of roundings in otel-js it can lead to cors timestamps (input = 0) to be less than `performance.timeOrigin`

<img width="1359" alt="image" src="https://github.com/signalfx/splunk-otel-js-web/assets/1122555/75c1440e-0085-4445-a583-e310f72bd7ef">

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- Manual testing

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
