### PR TITLE
Fix gitlab ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,8 +13,6 @@ cache:
   paths:
     - "./node_modules"
     - "./packages/*/node_modules"
-    # puppeteer cache
-    - "/home/circleci/.cache"
 
 stages:
   - setup

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,8 @@ cache:
   paths:
     - "./node_modules"
     - "./packages/*/node_modules"
+    # puppeteer cache
+    - "~/.cache"
 
 stages:
   - setup

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,6 +74,7 @@ build_artifacts:
 unit_test:
   stage: test
   script:
+    - npm ci --include=dev
     - npm run test:unit:ci
 
 oss-scan:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ cache:
     - "./node_modules"
     - "./packages/*/node_modules"
     # puppeteer cache
-    - "~/.cache"
+    - "/home/circleci/.cache"
 
 stages:
   - setup


### PR DESCRIPTION
```
> nyc karma start --single-run --no-auto-watch --browsers ChromeHeadless
02 08 2023 14:06:54.849:ERROR [config]: Error in config file!
  Error: Could not find Chrome (ver. 115.0.5790.98). This can occur if either
 1. you did not perform an installation before running the script (e.g. `npm install`) or
 2. your cache path is incorrectly configured (which is: /home/circleci/.cache/puppeteer).
For (2), check out our guide on configuring puppeteer at https://pptr.dev/guides/configuration.
```

Gitlab doesn't like to cache directories outside project so re-running `npm ci` is the only way