### PR TITLE
fix(socketio-instrumentation): use apply instead of call method when invoking the 'on' callback

### DIFF
--- a/packages/web/src/SplunkSocketIoClientInstrumentation.ts
+++ b/packages/web/src/SplunkSocketIoClientInstrumentation.ts
@@ -155,7 +155,7 @@ export class SplunkSocketIoClientInstrumentation extends InstrumentationBase {
             });
 
             try {
-              listener.call(this, args);
+              listener.apply(this, args);
             } catch (error) {
               if (error instanceof Error) {
                 span.recordException(error);


### PR DESCRIPTION
# Description
The `call` method invokes the callback with `args` array as the first argument instead of spreading them, and as a side effect changes the data flow. The `apply` method instead spreads those args into individual arguments for the function.

[Socket.io documentation](https://socket.io/docs/v3/emitting-events/#acknowledgements) shows that data should be passed as it is received and not wrapped in an array

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- Manual testing

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
