### PR TITLE
Fix links

### DIFF
--- a/docs/DataModel.md
+++ b/docs/DataModel.md
@@ -11,7 +11,7 @@ Splunk RUM data model represents the following logical entities:
 |Interaction|Reflects the action the user conducts within the user interface. Common interaction types include mouse clicks, taps on a touchscreen and keyboard events.|
 |User|A representation of the user interacting with the application. An user can be represented with the username, email address or a synthetic identifier. Synthetic representation is preferred in situations where PII regulations do not allow identifying the real user. By default, Splunk Browser Agent is not detecting the identity. Mapping a trace to the specific user is possible via manual instrumentation using the Browser Agent API.|
 
-The data model closely follows OpenTelemetry’s [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions). Deviations are kept minimal. 
+The data model closely follows OpenTelemetry’s [semantic conventions](https://github.com/open-telemetry/semantic-conventions/tree/main/docs). Deviations are kept minimal. 
 
 All of the data is currently sent in batches, containing modified Zipkin spans encoded as JSON objects. A single batch can contain one or more spans. Spans have universal properties and in addition every instrumentation can add their own properties. 
 
@@ -36,11 +36,11 @@ All of the data is currently sent in batches, containing modified Zipkin spans e
 |`component`|`string`|Instrumentation name that produced this span, such as `document-load`.|
 |`location.href`|`string`|Value of [`location.href`](https://developer.mozilla.org/en-US/docs/Web/API/Location/href) at the moment of creating the span.|
 |`splunk.rumSessionId`|`string`|Session ID, captured from the \_splunk_rum_sid cookie.|
-|`splunk.rumVersion` [`telemetry.sdk.version`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#telemetry-sdk)|`string`|Version of the Splunk RUM SDK instrumenting the application.|
+|`splunk.rumVersion` [`telemetry.sdk.version`](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#telemetry-sdk)|`string`|Version of the Splunk RUM SDK instrumenting the application.|
 |`splunk.scriptInstance`|`string`|64bit id. Every instance of splunk-otel-web.js gets assigned its own id eg. to distinguish between different open tabs within the same browser window sharing the same session. This is not persisted so every time page is reloaded it will have new value.|
 |`otel.status_code`|`string`|["OK" or "ERROR", if set](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/zipkin.md#status)|
-|[`telemetry.sdk.language`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#telemetry-sdk)|`string`|Always `"webjs"`|
-|[`telemetry.sdk.name`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#telemetry-sdk)|`string`|Always `"@splunk/otel-web"`|
+|[`telemetry.sdk.language`](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#telemetry-sdk)|`string`|Always `"webjs"`|
+|[`telemetry.sdk.name`](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#telemetry-sdk)|`string`|Always `"@splunk/otel-web"`|
 
 ## HTTP request timings annotations
 

--- a/docs/IdentifyingUsers.md
+++ b/docs/IdentifyingUsers.md
@@ -4,7 +4,7 @@
 
 RUM does not do anything automatically to link traces to the user visiting the site. However it can be useful to use user information to filter or debug traces. This information can be added using global attributes - attributes that get attached to every span.
 
-[OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-identity-attributes) provides some common attributes for identifying attributes. For RUM use we recommend: 
+[OpenTelemetry Specification](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attributes.md#general-identity-attributes) provides some common attributes for identifying attributes. For RUM use we recommend: 
 
 | Attribute | Description | Examples |
 |---|---|---|

--- a/docs/Instrumentations.md
+++ b/docs/Instrumentations.md
@@ -68,18 +68,18 @@ The annotations captured by the `resourceFetch` instrumentation are described in
 
 This instrumentation prepends the span `name` with HTTP + HTTP method name (eg. `GET`, `POST`). If the `XHF/Fetch` maps to a backend providing a `server-timing` header in the response, the link with the backend trace is also created by this instrumentation. 
 
-All the tags captured by the instrumentation and exposed in next table follow OpenTelemetry [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes): 
+All the tags captured by the instrumentation and exposed in next table follow OpenTelemetry [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#common-attributes): 
 
 |Name| Type and Description|
 |---|---|
-`http.method`|As specified in OpenTelemetry [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes)|
-`http.response_content_length`|As specified in OpenTelemetry [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes)|
-`http.host`|As specified in OpenTelemetry [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes)|
-`http.scheme`|As specified in OpenTelemetry [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes)|
-`http.status_code`|As specified in OpenTelemetry [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes)|
-`http.status_text`|As specified in OpenTelemetry [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes)|
-`http.user_agent`|As specified in OpenTelemetry [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes)|
-`http.url`|As specified in OpenTelemetry [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes)|
+`http.method`|As specified in OpenTelemetry [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#common-attributes)|
+`http.response_content_length`|As specified in OpenTelemetry [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#common-attributes)|
+`http.host`|As specified in OpenTelemetry [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#common-attributes)|
+`http.scheme`|As specified in OpenTelemetry [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#common-attributes)|
+`http.status_code`|As specified in OpenTelemetry [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#common-attributes)|
+`http.status_text`|As specified in OpenTelemetry [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#common-attributes)|
+`http.user_agent`|As specified in OpenTelemetry [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#common-attributes)|
+`http.url`|As specified in OpenTelemetry [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#common-attributes)|
 
 In addition, the `XHR/Fetch` instrumentation annotates the span with timestamps representing the time when the following XHR events fired:
 
@@ -214,7 +214,7 @@ Captures information from `send` and `onmessage` events.
 
 ## Instrumentation: Socket.io client
 
-This instrumentation generates spans from messages sent using the [socket.io](https://socket.io/) client library. Generated spans conform to the [OpenTelemetry specifications on messaging systems](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md). This instrumentation is disabled by default and versions from v1 to v4 of socket.io-client are supported.
+This instrumentation generates spans from messages sent using the [socket.io](https://socket.io/) client library. Generated spans conform to the [OpenTelemetry specifications on messaging systems](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md). This instrumentation is disabled by default and versions from v1 to v4 of socket.io-client are supported.
 
 ### Setup
 


### PR DESCRIPTION
# Description

Fix docs/ links that now 404 due to moving stuff from otel-spec -> sem-convs 

## Type of change

- Chore or internal change (changes not visible to the consumers of the package)

# How has this been tested?

- Linkchecker CI

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
