### PR TITLE
Generate version that replaces Math.random with crypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "@splunk/otel-web-dev-root",
       "version": "0.17.0-beta.1",
       "workspaces": [
-        "packages/*"
+        "packages/web",
+        "packages/session-recorder"
       ],
       "devDependencies": {
         "@aws-sdk/client-cloudfront": "^3.171.0",
@@ -20,6 +21,7 @@
         "dotenv": "^16.3.1",
         "eslint": "^8.45.0",
         "eslint-plugin-header": "^3.1.1",
+        "magic-string": "^0.30.8",
         "typescript": "^5.1.6"
       },
       "engines": {
@@ -3812,6 +3814,18 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-commonjs/node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@rollup/plugin-inject": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.3.tgz",
@@ -3832,6 +3846,18 @@
         "rollup": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@rollup/plugin-inject/node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@rollup/plugin-json": {
@@ -11709,12 +11735,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
-      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "version": "0.30.8",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       },
       "engines": {
         "node": ">=12"
@@ -19801,6 +19827,17 @@
         "glob": "^8.0.3",
         "is-reference": "1.2.1",
         "magic-string": "^0.27.0"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+          "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
+        }
       }
     },
     "@rollup/plugin-inject": {
@@ -19812,6 +19849,17 @@
         "@rollup/pluginutils": "^5.0.1",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.27.0"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+          "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
+        }
       }
     },
     "@rollup/plugin-json": {
@@ -26027,12 +26075,12 @@
       }
     },
     "magic-string": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
-      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "version": "0.30.8",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
       "dev": true,
       "requires": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       }
     },
     "make-dir": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "compile": "npm run --ws compile --",
+    "generate:security-theater": "node ./scripts/security-theater-generator.mjs",
     "lint": "eslint --ignore-path .gitignore packages/*/src/ packages/*/test/ packages/*/integration-tests/",
     "lint:markdown": "markdownlint *.md docs/*.md",
     "lint:fix": "eslint --ignore-path .gitignore --fix  packages/*/src/ packages/*/test/ packages/*/integration-tests/",
@@ -47,6 +48,7 @@
     "dotenv": "^16.3.1",
     "eslint": "^8.45.0",
     "eslint-plugin-header": "^3.1.1",
+    "magic-string": "^0.30.8",
     "typescript": "^5.1.6"
   }
 }

--- a/scripts/security-theater-generator.mjs
+++ b/scripts/security-theater-generator.mjs
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { readFile, writeFile } from 'node:fs/promises';
+import MagicString from 'magic-string';
+
+const source = await readFile('packages/web/dist/artifacts/splunk-otel-web.js', { encoding: 'utf-8' });
+
+const string = new MagicString(source);
+string.replaceAll('Math.random()', '(crypto.getRandomValues(new Uint32Array(1))[0]/Math.pow(2,32))');
+
+writeFile('packages/web/dist/artifacts/splunk-otel-web-security-theater-edition.js', string.toString());
+// future (rollup plugin?) - can we do something with sourcemap from string.generateMap?

--- a/scripts/security-theater-generator.mjs
+++ b/scripts/security-theater-generator.mjs
@@ -20,7 +20,7 @@ import MagicString from 'magic-string';
 const source = await readFile('packages/web/dist/artifacts/splunk-otel-web.js', { encoding: 'utf-8' });
 
 const string = new MagicString(source);
-string.replaceAll('Math.random()', '(crypto.getRandomValues(new Uint32Array(1))[0]/Math.pow(2,32))');
+string.replaceAll('Math.random()', '(crypto.getRandomValues(new Uint32Array(1))[0]/4294967295)');
 
 writeFile('packages/web/dist/artifacts/splunk-otel-web-security-theater-edition.js', string.toString());
 // future (rollup plugin?) - can we do something with sourcemap from string.generateMap?


### PR DESCRIPTION
# Description

Generate a version of bundled agent where Math.random is replaced with crypto functions, useful in case I want to use a static code scanning tool but [ignore it's documentation](https://codeql.github.com/codeql-query-help/javascript/js-insecure-randomness/#:~:text=Use%20a%20cryptographically%20secure%20pseudo%2Drandom%20number%20generator%20if%20the%20output%20is%20to%20be%20used%20in%20a%20security%2Dsensitive%20context) (skill issue)

## Type of change

- Chore or internal change (changes not visible to the consumers of the package)

# How has this been tested?

- Manual testing

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
