### PR TITLE
Allow broader Element, rather than HTMLELement in user interactions

### DIFF
--- a/packages/web/integration-tests/tests/user-interaction/mouse.ejs
+++ b/packages/web/integration-tests/tests/user-interaction/mouse.ejs
@@ -10,12 +10,21 @@
   <h1>Mouse events test</h1>
 
   <button type="button" id="btn1">Button</button>
+  <button type="button" id="btnSvg">
+    <svg width="10" height="10" >
+      <rect id="btn-svg-target" width="100%" height="100%" fill="red" />
+    </svg>
+  </button>
 
   <pre id="scenarioDisplay"></pre>
   <script id="scenario">
     btn1.addEventListener('click', function () {});
     btn1.addEventListener('mousedown', function () {});
     btn1.addEventListener('mouseup', function () {});
+
+    btnSvg.addEventListener('click', function () {});
+    btnSvg.addEventListener('mousedown', function () {});
+    btnSvg.addEventListener('mouseup', function () {});
   </script>
   <script>scenarioDisplay.innerHTML = scenario.innerHTML;</script>
 </body>

--- a/packages/web/integration-tests/tests/user-interaction/mouse.spec.js
+++ b/packages/web/integration-tests/tests/user-interaction/mouse.spec.js
@@ -98,6 +98,41 @@ module.exports = {
     await browser.url(browser.globals.getUrl('/user-interaction/mouse-bubble.ejs'));
     await browser.click('#inner');
 
-    browser.expect.element('#result').text.to.equal('container');
-  }
+    await browser.globals.findSpan(span => span.name === 'click');
+    await browser.expect.element('#result').text.to.equal('container');
+
+    await browser.globals.assertNoErrorSpans();
+  },
+  'handles svg interactions': async function(browser) {
+    browser.globals.clearReceivedSpans();
+
+    await browser.url(browser.globals.getUrl('/user-interaction/mouse.ejs'));
+    await browser.click('#btn-svg-target');
+
+    const clickSpan = await browser.globals.findSpan(span => span.name === 'click');
+    await browser.assert.ok(!!clickSpan, 'Checking click span presence.');
+
+    await browser.assert.strictEqual(clickSpan.tags['component'], 'user-interaction');
+    await browser.assert.strictEqual(clickSpan.tags['event_type'], 'click');
+    await browser.assert.strictEqual(clickSpan.tags['target_element'], 'rect');
+    await browser.assert.strictEqual(clickSpan.tags['target_xpath'], '//*[@id="btn-svg-target"]');
+
+    const mouseDownSpan = await browser.globals.findSpan(span => span.name === 'mousedown');
+    await browser.assert.ok(!!mouseDownSpan, 'Checking mousedown span presence.');
+
+    await browser.assert.strictEqual(mouseDownSpan.tags['component'], 'user-interaction');
+    await browser.assert.strictEqual(mouseDownSpan.tags['event_type'], 'mousedown');
+    await browser.assert.strictEqual(mouseDownSpan.tags['target_element'], 'rect');
+    await browser.assert.strictEqual(mouseDownSpan.tags['target_xpath'], '//*[@id="btn-svg-target"]');
+
+    const mouseUpSpan = await browser.globals.findSpan(span => span.name === 'mouseup');
+    await browser.assert.ok(!!mouseUpSpan, 'Checking mouseup span presence.');
+
+    await browser.assert.strictEqual(mouseUpSpan.tags['component'], 'user-interaction');
+    await browser.assert.strictEqual(mouseUpSpan.tags['event_type'], 'mouseup');
+    await browser.assert.strictEqual(mouseUpSpan.tags['target_element'], 'rect');
+    await browser.assert.strictEqual(mouseUpSpan.tags['target_xpath'], '//*[@id="btn-svg-target"]');
+
+    await browser.globals.assertNoErrorSpans();
+  },
 };

--- a/packages/web/src/upstream/user-interaction/types.ts
+++ b/packages/web/src/upstream/user-interaction/types.ts
@@ -22,7 +22,7 @@ export type EventName = keyof HTMLElementEventMap;
 
 export type ShouldPreventSpanCreation = (
   eventType: EventName,
-  element: HTMLElement,
+  element: Element,
   span: Span
 ) => boolean | void;
 


### PR DESCRIPTION
# Description

Existing handler filters incoming events by target being of type `HTMLElement` which excludes SVG elements. This PR extends the allowed type to `Element`.

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added integration tests
