### PR TITLE
Make webvitals metrics individually disableable/configurable

### DIFF
--- a/packages/web/integration-tests/tests/webvitals/webvitals-specific-disabled.ejs
+++ b/packages/web/integration-tests/tests/webvitals/webvitals-specific-disabled.ejs
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Webvitals</title>
+
+	<%- renderAgent({debug: true, instrumentations: {webvitals: {lcp: false, cls: false}}}) %>
+	
+	<style>
+		#container {
+			height: 200px;
+			width: 400px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Webvitals</h1>
+
+	<!-- a dummy "interactive" link in order to compute FID -->
+	<a href="javascript:clicky()" id="clicky">Click me</a>
+
+	<div id="container">Don't shift me : (</div>
+	<script>
+		let id = 1;
+		const container = document.getElementById('container');
+		function clicky() {
+			const p = document.createElement('p');
+			p.setAttribute('id', 'p'+id);
+			id++;
+			p.innerText = 'Very long paragraph to force a visual change.  '.repeat(30);			
+			container.insertBefore(p, container.firstChild);
+		}
+		window.addEventListener('load', clicky);
+	</script>
+</body>
+</html>

--- a/packages/web/integration-tests/tests/webvitals/webvitals.spec.js
+++ b/packages/web/integration-tests/tests/webvitals/webvitals.spec.js
@@ -35,6 +35,43 @@ module.exports = {
     // force a sync
     await browser.globals.waitForTestToFinish();
 
+    const fid = await browser.globals.findSpan(span => span.tags.fid !== undefined);
+    const inp = await browser.globals.findSpan(span => span.tags.inp !== undefined);
+
+    browser.assert.ok(!!browser.globals.getReceivedSpans().find(span => span.tags.lcp !== undefined), 'Checking presence of lcp span.');
+    browser.assert.ok(!!browser.globals.getReceivedSpans().find(span => span.tags.cls !== undefined), 'Checking presence of cls span.');
+
+    // sometimes missing in automated tests
+    if (fid) {
+      await browser.assert.strictEqual(fid.name, 'webvitals');
+      await browser.assert.ok(fid.tags.fid > 0);
+    }
+    if (inp) {
+      await browser.assert.strictEqual(inp.name, 'webvitals');
+    }
+
+    await browser.globals.assertNoErrorSpans();
+  },
+  'webvitals - specific metrics disabled': async function(browser) {
+    // the google webvitals library only works on chrome (and chrome-based edge) at the moment
+    if (!browser.globals.isBrowser({ chrome: true, microsoftedge: true })) {
+      return;
+    }
+
+    const url = browser.globals.getUrl('/webvitals/webvitals-specific-disabled.ejs');
+    await browser.url(url);
+    // fid won't happen unless there is interaction, so simulate a bit of that
+    await browser.click('#clicky');
+    await browser.waitForElementPresent('#p2');
+    // webvitals library won't send the cls unless a visibility change happens, so
+    // force a fake one
+    await browser.execute(function() {
+      Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    // force a sync
+    await browser.globals.waitForTestToFinish();
+
     const lcp = await browser.globals.findSpan(span => span.tags.lcp !== undefined);
     const cls = await browser.globals.findSpan(span => span.tags.cls !== undefined);
     const fid = await browser.globals.findSpan(span => span.tags.fid !== undefined);
@@ -59,5 +96,5 @@ module.exports = {
     }
 
     await browser.globals.assertNoErrorSpans();
-  }
+  },
 };

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -44,7 +44,7 @@ import { ERROR_INSTRUMENTATION_NAME, SplunkErrorInstrumentation } from './Splunk
 import { generateId, getPluginConfig, registerGlobal } from './utils';
 import { getRumSessionId, initSessionTracking, SessionIdType } from './session';
 import { SplunkWebSocketInstrumentation } from './SplunkWebSocketInstrumentation';
-import { initWebVitals } from './webvitals';
+import { WebVitalsInstrumentationConfig, initWebVitals } from './webvitals';
 import { SplunkLongTaskInstrumentation } from './SplunkLongTaskInstrumentation';
 import { SplunkPageVisibilityInstrumentation } from './SplunkPageVisibilityInstrumentation';
 import { SplunkConnectivityInstrumentation } from './SplunkConnectivityInstrumentation';
@@ -86,7 +86,7 @@ interface SplunkOtelWebOptionsInstrumentations {
   postload?:     boolean | SplunkPostDocLoadResourceInstrumentationConfig;
   socketio?:     boolean | SocketIoClientInstrumentationConfig;
   websocket?:    boolean | InstrumentationConfig;
-  webvitals?:    boolean;
+  webvitals?:    boolean | WebVitalsInstrumentationConfig;
   xhr?:          boolean | XMLHttpRequestInstrumentationConfig;
 }
 
@@ -503,7 +503,7 @@ export const SplunkRum: SplunkOtelWebType = {
 
     const vitalsConf = getPluginConfig(processedOptions.instrumentations.webvitals);
     if (vitalsConf !== false) {
-      initWebVitals(provider);
+      initWebVitals(provider, vitalsConf);
     }
 
     inited = true;


### PR DESCRIPTION
# Description

Allows users to individually disable specific metrics (if they have their own calculation method) or pass configuration

## Type of change

- New feature (non-breaking change which adds functionality)

# How has this been tested?

- Manual testing
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
