### PR TITLE
Optionally allow all spans to count as activity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5478,6 +5478,21 @@
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.5.tgz",
       "integrity": "sha512-9Hp0ObzwwO57DpLFF0InUjUm/II8GmKAvzbefxQTihCb7KI6yc9yzf0nLc4mVdby5N4DRCgQM2wCup9KTieeww=="
     },
+    "node_modules/@types/sinon": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true
+    },
     "node_modules/@types/ws": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
@@ -17583,6 +17598,7 @@
         "@types/mocha": "^10.0.1",
         "@types/nightwatch": "^2.3.24",
         "@types/shimmer": "^1.0.2",
+        "@types/sinon": "^17.0.3",
         "body-parser": "^1.20.2",
         "chai": "^4.3.7",
         "chrome-launcher": "^1.0.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -76,6 +76,7 @@
     "@types/mocha": "^10.0.1",
     "@types/nightwatch": "^2.3.24",
     "@types/shimmer": "^1.0.2",
+    "@types/sinon": "^17.0.3",
     "body-parser": "^1.20.2",
     "chai": "^4.3.7",
     "chrome-launcher": "^1.0.0",

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -25,8 +25,13 @@ export function generateId(bits: number): string {
   });
 }
 
+export const cookieStore = {
+  set: (value: string): void => { document.cookie = value; },
+  get: (): string => document.cookie,
+};
+
 export function findCookieValue(cookieName: string): string | undefined {
-  const decodedCookie = decodeURIComponent(document.cookie);
+  const decodedCookie = decodeURIComponent(cookieStore.get());
   const cookies = decodedCookie.split(';');
   for (let i = 0; i < cookies.length; i++) {
     const c = cookies[i].trim();

--- a/packages/web/test/SessionBasedSampler.test.ts
+++ b/packages/web/test/SessionBasedSampler.test.ts
@@ -19,6 +19,7 @@ import { InternalEventTarget } from '../src/EventTarget';
 import { SessionBasedSampler } from '../src/SessionBasedSampler';
 import { initSessionTracking, COOKIE_NAME, updateSessionStatus } from '../src/session';
 import { context, SamplingDecision } from '@opentelemetry/api';
+import { SplunkWebTracerProvider } from '../src';
 
 describe('Session based sampler', () => {
   it('decide sampling based on session id and ratio', () => {
@@ -26,7 +27,8 @@ describe('Session based sampler', () => {
     const lowSessionId = '0'.repeat(32);
     const lowCookieValue = encodeURIComponent(JSON.stringify({ id: lowSessionId, startTime: new Date().getTime() }));
     document.cookie = COOKIE_NAME + '=' + lowCookieValue + '; path=/; max-age=' + 10;
-    initSessionTracking(lowSessionId, new InternalEventTarget());
+    const provider = new SplunkWebTracerProvider();
+    initSessionTracking(provider, lowSessionId, new InternalEventTarget());
 
     const sampler = new SessionBasedSampler({ ratio: 0.5 });
     assert.strictEqual(


### PR DESCRIPTION
# Description

Currently, we only count user interactions as activity when tracking sessions, this PR adds a config option to allow any span to count as activity.

## Type of change

- New feature (non-breaking change which adds functionality)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
