### PR TITLE
Protect against multiple instances running in the same context

### DIFF
--- a/packages/web/src/global-utils.ts
+++ b/packages/web/src/global-utils.ts
@@ -1,0 +1,71 @@
+/*
+Copyright 2024 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { diag } from '@opentelemetry/api';
+import { VERSION } from './version';
+
+const GLOBAL_OPENTELEMETRY_API_KEY = Symbol.for('opentelemetry.js.api.1');
+
+/**
+ * otel-api's global function. This isn't exported by otel/api but would be
+ * super useful to register global components for experimental purposes...
+ * For us, it's included to register components accessed by other packages,
+ * eg. sharing session id manager with session recorder
+ */
+export function registerGlobal(
+  type: string,
+  instance: unknown,
+  allowOverride = false
+): boolean {
+  if (!globalThis[GLOBAL_OPENTELEMETRY_API_KEY]) {
+    diag.error('SplunkRum: Tried to access global before otel setup');
+    return false;
+  }
+  const api = globalThis[GLOBAL_OPENTELEMETRY_API_KEY];
+
+  if (!api['splunk.rum.version']) {
+    api['splunk.rum.version'] = VERSION;
+  }
+  if (api['splunk.rum.version'] !== VERSION) {
+    diag.error(`SplunkRum: Global: Multiple versions detected (${VERSION} already registered)`);
+    return false;
+  }
+
+  if (!allowOverride && api[type]) {
+    diag.error(`SplunkRum: Attempted duplicate registration of otel API ${type}`);
+    return false;
+  }
+
+  api[type] = instance;
+  return true;
+}
+
+export function unregisterGlobal(
+  type: string,
+): boolean {
+  const api = globalThis[GLOBAL_OPENTELEMETRY_API_KEY];
+  if (!api) {
+    diag.warn(`OTel API ref was missing while trying to unregister ${type}`);
+    return false;
+  }
+
+  if (!!api['splunk.rum.version'] && api['splunk.rum.version'] !== VERSION) {
+    diag.warn(`SplunkRum version in OTel API ref (${api['splunk.rum.version']}) didn't match our version (${VERSION}).`);
+  }
+
+  delete api[type];
+  return true;
+}

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -14,9 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { diag } from '@opentelemetry/api';
 import { wrap } from 'shimmer';
-import { VERSION } from './version';
 
 export function generateId(bits: number): string {
   const xes = 'x'.repeat(bits/4);
@@ -169,38 +167,4 @@ export function waitForGlobal(identifier: string, callback: (value: unknown) => 
       window[identifier] = value;
     }
   };
-}
-
-const GLOBAL_OPENTELEMETRY_API_KEY = Symbol.for('opentelemetry.js.api.1');
-/**
- * otel-api's global function. This isn't exported by otel/api but would be
- * super useful to register global components for experimental purposes...
- * For us, it's included to register components accessed by other packages,
- * eg. sharing session id manager with session recorder
- */
-export function registerGlobal(
-  type: string,
-  instance: unknown,
-  allowOverride = false
-): boolean {
-  if (!globalThis[GLOBAL_OPENTELEMETRY_API_KEY]) {
-    diag.error('SplunkRum: Tried to access global before otel setup');
-    return false;
-  }
-  const api = globalThis[GLOBAL_OPENTELEMETRY_API_KEY];
-
-  if (!api['splunk.rum.version']) {
-    api['splunk.rum.version'] = VERSION;
-  }
-  if (api['splunk.rum.version'] !== VERSION) {
-    diag.warn(`SplunkRum: Global: Multiple versions detected (${VERSION} already registered)`);
-  }
-
-  if (!allowOverride && api[type]) {
-    diag.error(`SplunkRum: Attempted duplicate registration of otel API ${type}`);
-    return false;
-  }
-
-  api[type] = instance;
-  return true;
 }

--- a/packages/web/test/utils.ts
+++ b/packages/web/test/utils.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { ReadableSpan, SimpleSpanProcessor, SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import SplunkRum, { SplunkZipkinExporter } from '../src/index';
 import { ZipkinSpan } from '../src/exporters/zipkin';
+import { assert } from 'chai';
 
 export class SpanCapturer implements SpanProcessor {
   public readonly spans: ReadableSpan[] = [];
@@ -65,7 +66,8 @@ export function initWithDefaultConfig(capturer: SpanCapturer, additionalOptions 
     rumAccessToken: '123-no-warn-spam-in-console',
     ...additionalOptions,
   });
-  SplunkRum.provider.addSpanProcessor(capturer);
+  assert.ok(SplunkRum.inited);
+  SplunkRum.provider!.addSpanProcessor(capturer);
 }
 
 export function initWithSyncPipeline(additionalOptions = {}): {
@@ -94,6 +96,6 @@ export function initWithSyncPipeline(additionalOptions = {}): {
   };
 }
 
-export function deinit(): void {
-  SplunkRum.deinit();
+export function deinit(force?: boolean): void {
+  SplunkRum.deinit(force);
 }


### PR DESCRIPTION
# Description

Uses global `window[Symbol.for('opentelemetry.js.api.1')]` to track if more than one instance of `SplunkRum` active within a given context.

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How has this been tested?

- Manual testing
- Added unit tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
