### PR TITLE
add source_map_ids to error span attributes

### DIFF
--- a/packages/web/integration-tests/tests/errors/index.spec.js
+++ b/packages/web/integration-tests/tests/errors/index.spec.js
@@ -175,5 +175,26 @@ module.exports = {
     await browser.globals.waitForTestToFinish();
 
     browser.assert.not.ok(browser.globals.getReceivedSpans().find(({ name }) => name === 'onerror'), 'Checking lack of error span.');
+  },
+  'minified script with source map id': async function(browser) {
+    await browser.url(browser.globals.getUrl('/errors/views/minified_file_errors.ejs'));
+    // click on button1 to trigger error
+    await browser.click('#button1');
+    await browser.pause(1000);
+    const errorSpan1 = await browser.globals.findSpan(s => s.name === 'onerror');
+    await browser.assert.ok(!!errorSpan1, 'Checking presence of error span.');
+    await browser.assert.strictEqual(errorSpan1.tags['error.message'], 'Error from script1.js');
+    // check errorSpan2.tags['error.source_map_ids'] contains the strings script1.min.js and the hash text
+    await browser.assert.ok(errorSpan1.tags['error.source_map_ids'].includes('script1.min.js'));
+    await browser.assert.ok(errorSpan1.tags['error.source_map_ids'].includes('9663c60664c425cef3b141c167e9b324240ce10ae488726293892b7130266a6b'));
+    // clear spans and do same for button2
+    browser.globals.clearReceivedSpans();
+    await browser.click('#button2');
+    await browser.pause(1000);
+    const errorSpan2 = await browser.globals.findSpan(s => s.name === 'onerror');
+    await browser.assert.ok(!!errorSpan2, 'Checking presence of error span.');
+    await browser.assert.strictEqual(errorSpan2.tags['error.message'], 'Error from script2.js');
+    await browser.assert.ok(errorSpan2.tags['error.source_map_ids'].includes('script2.min.js'));
+    await browser.assert.ok(errorSpan2.tags['error.source_map_ids'].includes('9793573cdc2ab308a0b1996bea14253ec8832bc036210475ded0813cafa27066'));
   }
 };

--- a/packages/web/integration-tests/tests/errors/views/minified_file_errors.ejs
+++ b/packages/web/integration-tests/tests/errors/views/minified_file_errors.ejs
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Errors test</title>
+  <%- renderAgent({}) %>
+</head>
+<body>
+    <h1>Minified files with source map ids</h1>
+    <button id="button1">Button 1</button>
+    <button id="button2">Button 2</button>
+    <script src="/integration-tests/tests/errors/views/script1.min.js" type="module"></script>
+    <script src="/integration-tests/tests/errors/views/script2.min.js"></script>
+</body>
+</html>

--- a/packages/web/integration-tests/tests/errors/views/script1.min.js
+++ b/packages/web/integration-tests/tests/errors/views/script1.min.js
@@ -1,0 +1,18 @@
+/*
+Copyright 2024 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+document.getElementById('button1').addEventListener('click',function(){throw new Error('Error from script1.js');});
+window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\/\/[^\s]+?(?::\d+)?(?=:[\d]+:[\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '9663c60664c425cef3b141c167e9b324240ce10ae488726293892b7130266a6b';}

--- a/packages/web/integration-tests/tests/errors/views/script2.min.js
+++ b/packages/web/integration-tests/tests/errors/views/script2.min.js
@@ -1,0 +1,18 @@
+/*
+Copyright 2024 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+document.getElementById('button2').addEventListener('click',function(){throw new Error('Error from script2.js');});
+window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\/\/[^\s]+?(?::\d+)?(?=:[\d]+:[\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '9793573cdc2ab308a0b1996bea14253ec8832bc036210475ded0813cafa27066';}


### PR DESCRIPTION
# Description

retrieve source map ids of files in stacktrace
add source_map_ids to error span attributes

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Documentation update

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
