### PR TITLE
 chore: enable `@typescript-eslint/member-ordering` rule 

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -82,80 +82,79 @@ export default [
 			],
 			'@typescript-eslint/explicit-function-return-type': 'off',
 			'@typescript-eslint/interface-name-prefix': 'off',
-			// '@typescript-eslint/member-ordering': [
-			//   'error',
-			//   {
-			//     default: {
-			//       memberTypes: [
-			//         // Index signature
-			//         'signature',
-			//
-			//         // Fields
-			//         'public-static-field',
-			//         'protected-static-field',
-			//         'private-static-field',
-			//
-			//         'public-decorated-field',
-			//         'protected-decorated-field',
-			//         'private-decorated-field',
-			//
-			//         'public-instance-field',
-			//         'protected-instance-field',
-			//         'private-instance-field',
-			//
-			//         'public-abstract-field',
-			//         'protected-abstract-field',
-			//
-			//         'public-field',
-			//         'protected-field',
-			//         'private-field',
-			//
-			//         'static-field',
-			//         'instance-field',
-			//         'abstract-field',
-			//
-			//         'decorated-field',
-			//
-			//         'field',
-			//
-			//         // Constructors
-			//         'public-constructor',
-			//         'protected-constructor',
-			//         'private-constructor',
-			//
-			//         'constructor',
-			//
-			//         // Methods
-			//         'public-decorated-method',
-			//         'public-static-method',
-			//         'public-instance-method',
-			//         'protected-decorated-method',
-			//         'protected-static-method',
-			//         'protected-instance-method',
-			//         'private-decorated-method',
-			//         'private-static-method',
-			//         'private-instance-method',
-			//
-			//         'public-abstract-method',
-			//         'protected-abstract-method',
-			//
-			//         'public-method',
-			//         'protected-method',
-			//         'private-method',
-			//
-			//         'static-method',
-			//         'instance-method',
-			//         'abstract-method',
-			//
-			//         'decorated-method',
-			//
-			//         'method',
-			//       ],
-			//       order: 'alphabetically',
-			//     },
-			//   },
-			// ],
-			'@typescript-eslint/member-ordering': 'off', // TODO: temporarily disabled
+			'@typescript-eslint/member-ordering': [
+				'error',
+				{
+					default: {
+						memberTypes: [
+							// Index signature
+							'signature',
+
+							// Fields
+							'public-static-field',
+							'protected-static-field',
+							'private-static-field',
+
+							'public-decorated-field',
+							'protected-decorated-field',
+							'private-decorated-field',
+
+							'public-instance-field',
+							'protected-instance-field',
+							'private-instance-field',
+
+							'public-abstract-field',
+							'protected-abstract-field',
+
+							'public-field',
+							'protected-field',
+							'private-field',
+
+							'static-field',
+							'instance-field',
+							'abstract-field',
+
+							'decorated-field',
+
+							'field',
+
+							// Constructors
+							'public-constructor',
+							'protected-constructor',
+							'private-constructor',
+
+							'constructor',
+
+							// Methods
+							'public-decorated-method',
+							'public-static-method',
+							'public-instance-method',
+							'protected-decorated-method',
+							'protected-static-method',
+							'protected-instance-method',
+							'private-decorated-method',
+							'private-static-method',
+							'private-instance-method',
+
+							'public-abstract-method',
+							'protected-abstract-method',
+
+							'public-method',
+							'protected-method',
+							'private-method',
+
+							'static-method',
+							'instance-method',
+							'abstract-method',
+
+							'decorated-method',
+
+							'method',
+						],
+						order: 'alphabetically',
+					},
+				},
+			],
 			'@typescript-eslint/naming-convention': ['error', { format: ['UPPER_CASE'], selector: ['enumMember'] }],
 			'@typescript-eslint/no-base-to-string': 'off',
 			'@typescript-eslint/no-empty-interface': 'off',

--- a/packages/session-recorder/src/OTLPLogExporter.ts
+++ b/packages/session-recorder/src/OTLPLogExporter.ts
@@ -23,10 +23,10 @@ import { IAnyValue, Log } from './types'
 import { VERSION } from './version.js'
 
 interface OTLPLogExporterConfig {
-	headers?: Record<string, string>
 	beaconUrl: string
-	getResourceAttributes: () => JsonObject
 	debug?: boolean
+	getResourceAttributes: () => JsonObject
+	headers?: Record<string, string>
 }
 
 const defaultHeaders = {

--- a/packages/session-recorder/src/index.ts
+++ b/packages/session-recorder/src/index.ts
@@ -33,6 +33,11 @@ interface BasicTracerProvider extends TracerProvider {
 type RRWebOptions = Parameters<typeof record>[0]
 
 export type SplunkRumRecorderConfig = RRWebOptions & {
+	/**
+	 * @deprecated Use RUM token in rumAccessToken
+	 */
+	apiToken?: string
+
 	/** Destination for the captured data */
 	beaconEndpoint?: string
 
@@ -40,6 +45,9 @@ export type SplunkRumRecorderConfig = RRWebOptions & {
 	 * @deprecated Use beaconEndpoint
 	 */
 	beaconUrl?: string
+
+	/** Debug mode */
+	debug?: boolean
 
 	/**
 	 * The name of your organization’s realm. Automatically configures beaconUrl with correct URL
@@ -58,14 +66,6 @@ export type SplunkRumRecorderConfig = RRWebOptions & {
 	 * @deprecated Renamed to `rumAccessToken`
 	 **/
 	rumAuth?: string
-
-	/**
-	 * @deprecated Use RUM token in rumAccessToken
-	 */
-	apiToken?: string
-
-	/** Debug mode */
-	debug?: boolean
 }
 
 function migrateConfigOption(

--- a/packages/session-recorder/src/types.ts
+++ b/packages/session-recorder/src/types.ts
@@ -19,9 +19,9 @@
 import type { JsonObject, JsonValue } from 'type-fest'
 
 export interface Log {
+	attributes?: JsonObject
 	body?: JsonValue
 	timeUnixNano: number
-	attributes?: JsonObject
 }
 
 export interface LogExporter {
@@ -36,28 +36,28 @@ export interface LogExporter {
 
 // OTLP Logs Interfaces
 export interface IAnyValue {
-	/** AnyValue stringValue */
-	stringValue?: string | null
+	/** AnyValue arrayValue */
+
+	arrayValue?: IArrayValue | null
 
 	/** AnyValue boolValue */
 	boolValue?: boolean | null
 
-	/** AnyValue intValue */
-	intValue?: number | null
+	/** AnyValue bytesValue */
+	bytesValue?: Uint8Array | null
 
 	/** AnyValue doubleValue */
 	doubleValue?: number | null
 
-	/** AnyValue arrayValue */
-
-	arrayValue?: IArrayValue | null
+	/** AnyValue intValue */
+	intValue?: number | null
 
 	/** AnyValue kvlistValue */
 
 	kvlistValue?: IKeyValueList | null
 
-	/** AnyValue bytesValue */
-	bytesValue?: Uint8Array | null
+	/** AnyValue stringValue */
+	stringValue?: string | null
 }
 
 export interface IArrayValue {

--- a/packages/web/performance-tests/injectingProxy/HtmlInjectorTransform.js
+++ b/packages/web/performance-tests/injectingProxy/HtmlInjectorTransform.js
@@ -18,18 +18,38 @@
 const { Transform } = require('stream')
 
 exports.HtmlInjectorTransform = class HtmlInjectorTransform extends Transform {
-	__scriptInjected = false
-
-	__wordIdx = 0
+	__content = []
 
 	__contentIdx = 0
 
-	__content = []
+	__scriptInjected = false
+
+	__wordIdx = 0
 
 	constructor({ matchingSuffix, contentToInject }) {
 		super()
 		this.__word = matchingSuffix
 		this.__injectable = contentToInject
+	}
+
+	__runPartialOnlineMatch() {
+		while (true) {
+			if (this.__contentIdx === this.__content.length) {
+				return false
+			} else if (this.__wordIdx === this.__word.length) {
+				return true
+			} else if (this.__contentIdx + this.__wordIdx === this.__content.length) {
+				return false
+			} else if (this.__content[this.__contentIdx + this.__wordIdx] === this.__word[this.__wordIdx]) {
+				this.__wordIdx += 1
+			} else if (this.__wordIdx === 0) {
+				this.__contentIdx += 1
+			} else {
+				// TODO: speed up using KMP failure function
+				this.__wordIdx = 0
+				this.__contentIdx += 1
+			}
+		}
 	}
 
 	_transform(chunk, enc, callback) {
@@ -61,26 +81,6 @@ exports.HtmlInjectorTransform = class HtmlInjectorTransform extends Transform {
 
 			this.push(toFlush.join('', 'utf-8'))
 			callback()
-		}
-	}
-
-	__runPartialOnlineMatch() {
-		while (true) {
-			if (this.__contentIdx === this.__content.length) {
-				return false
-			} else if (this.__wordIdx === this.__word.length) {
-				return true
-			} else if (this.__contentIdx + this.__wordIdx === this.__content.length) {
-				return false
-			} else if (this.__content[this.__contentIdx + this.__wordIdx] === this.__word[this.__wordIdx]) {
-				this.__wordIdx += 1
-			} else if (this.__wordIdx === 0) {
-				this.__contentIdx += 1
-			} else {
-				// TODO: speed up using KMP failure function
-				this.__wordIdx = 0
-				this.__contentIdx += 1
-			}
 		}
 	}
 }

--- a/packages/web/src/EventTarget.ts
+++ b/packages/web/src/EventTarget.ts
@@ -19,11 +19,11 @@
 import { Attributes } from '@opentelemetry/api'
 
 export interface SplunkOtelWebEventTypes {
-	'session-changed': {
-		sessionId: string
-	}
 	'global-attributes-changed': {
 		attributes: Attributes
+	}
+	'session-changed': {
+		sessionId: string
 	}
 }
 
@@ -42,18 +42,6 @@ export class InternalEventTarget {
 		;(this.events[type] as SplunkEventListener<T>[]).push(listener)
 	}
 
-	removeEventListener<T extends keyof SplunkOtelWebEventTypes>(type: T, listener: SplunkEventListener<T>): void {
-		if (!this.events[type]) {
-			return
-		}
-
-		const i = (this.events[type] as SplunkEventListener<T>[]).indexOf(listener)
-
-		if (i >= 0) {
-			this.events[type].splice(i, 1)
-		}
-	}
-
 	emit<T extends keyof SplunkOtelWebEventTypes>(type: T, payload: SplunkOtelWebEventTypes[T]): void {
 		const listeners = this.events[type]
 		if (!listeners) {
@@ -65,17 +53,32 @@ export class InternalEventTarget {
 			void Promise.resolve({ payload }).then(listener)
 		})
 	}
+
+	removeEventListener<T extends keyof SplunkOtelWebEventTypes>(type: T, listener: SplunkEventListener<T>): void {
+		if (!this.events[type]) {
+			return
+		}
+
+		const i = (this.events[type] as SplunkEventListener<T>[]).indexOf(listener)
+
+		if (i >= 0) {
+			this.events[type].splice(i, 1)
+		}
+	}
 }
 
 export interface SplunkOtelWebEventTarget {
-	addEventListener: InternalEventTarget['addEventListener']
 	/**
 	 * @deprecated Use {@link addEventListener}
 	 */
 	_experimental_addEventListener: InternalEventTarget['addEventListener']
-	removeEventListener: InternalEventTarget['removeEventListener']
+
 	/**
 	 * @deprecated Use {@link removeEventListener}
 	 */
 	_experimental_removeEventListener: InternalEventTarget['removeEventListener']
+
+	addEventListener: InternalEventTarget['addEventListener']
+
+	removeEventListener: InternalEventTarget['removeEventListener']
 }

--- a/packages/web/src/SessionBasedSampler.ts
+++ b/packages/web/src/SessionBasedSampler.ts
@@ -22,6 +22,12 @@ import { getRumSessionId } from './session'
 
 export interface SessionBasedSamplerConfig {
 	/**
+	 * Sampler called when session isn't being sampled
+	 * default: AlwaysOffSampler
+	 */
+	notSampled?: Sampler
+
+	/**
 	 * Ratio of sessions that get sampled (0.0 - 1.0, where 1 is all sessions)
 	 */
 	ratio?: number
@@ -31,26 +37,20 @@ export interface SessionBasedSamplerConfig {
 	 * default: AlwaysOnSampler
 	 */
 	sampled?: Sampler
-
-	/**
-	 * Sampler called when session isn't being sampled
-	 * default: AlwaysOffSampler
-	 */
-	notSampled?: Sampler
 }
 
 export class SessionBasedSampler implements Sampler {
-	protected _ratio: number
-
-	protected _upperBound: number
-
-	protected _sampled: Sampler
-
-	protected _notSampled: Sampler
-
 	protected _currentSession: string
 
 	protected _currentSessionSampled: boolean
+
+	protected _notSampled: Sampler
+
+	protected _ratio: number
+
+	protected _sampled: Sampler
+
+	protected _upperBound: number
 
 	constructor({
 		ratio = 1,
@@ -90,14 +90,6 @@ export class SessionBasedSampler implements Sampler {
 		return `SessionBased{ratio=${this._ratio}, sampled=${this._sampled.toString()}, notSampled=${this._notSampled.toString()}}`
 	}
 
-	private _normalize(ratio: number): number {
-		if (typeof ratio !== 'number' || isNaN(ratio)) {
-			return 0
-		}
-
-		return ratio >= 1 ? 1 : ratio <= 0 ? 0 : ratio
-	}
-
 	private _accumulate(sessionId: string): number {
 		let accumulation = 0
 		for (let i = 0; i < sessionId.length / 8; i++) {
@@ -106,5 +98,13 @@ export class SessionBasedSampler implements Sampler {
 			accumulation = (accumulation ^ part) >>> 0
 		}
 		return accumulation
+	}
+
+	private _normalize(ratio: number): number {
+		if (typeof ratio !== 'number' || isNaN(ratio)) {
+			return 0
+		}
+
+		return ratio >= 1 ? 1 : ratio <= 0 ? 0 : ratio
 	}
 }

--- a/packages/web/src/SplunkConnectivityInstrumentation.ts
+++ b/packages/web/src/SplunkConnectivityInstrumentation.ts
@@ -24,9 +24,9 @@ const MODULE_NAME = 'splunk-connectivity'
 export class SplunkConnectivityInstrumentation extends InstrumentationBase {
 	offlineListener: any
 
-	onlineListener: any
-
 	offlineStart: number | null
+
+	onlineListener: any
 
 	constructor(config: InstrumentationConfig = {}) {
 		super(MODULE_NAME, VERSION, Object.assign({}, config))
@@ -34,7 +34,10 @@ export class SplunkConnectivityInstrumentation extends InstrumentationBase {
 		this.offlineStart = navigator.onLine ? null : Date.now()
 	}
 
-	init(): void {}
+	disable(): void {
+		window.removeEventListener('offline', this.offlineListener)
+		window.removeEventListener('online', this.onlineListener)
+	}
 
 	enable(): void {
 		this.offlineListener = () => {
@@ -53,10 +56,7 @@ export class SplunkConnectivityInstrumentation extends InstrumentationBase {
 		window.addEventListener('online', this.onlineListener)
 	}
 
-	disable(): void {
-		window.removeEventListener('offline', this.offlineListener)
-		window.removeEventListener('online', this.onlineListener)
-	}
+	init(): void {}
 
 	private _createSpan(online: boolean, startTime: number) {
 		const span = this.tracer.startSpan('connectivity', { startTime })

--- a/packages/web/src/SplunkDocumentLoadInstrumentation.ts
+++ b/packages/web/src/SplunkDocumentLoadInstrumentation.ts
@@ -42,7 +42,7 @@ function addExtraDocLoadTags(span: api.Span) {
 }
 
 type PerformanceEntriesWithServerTiming = PerformanceEntries & {
-	serverTiming?: ReadonlyArray<{ name: string; duration: number; description: string }>
+	serverTiming?: ReadonlyArray<{ description: string; duration: number; name: string }>
 }
 
 type ExposedSuper = {

--- a/packages/web/src/SplunkLongTaskInstrumentation.ts
+++ b/packages/web/src/SplunkLongTaskInstrumentation.ts
@@ -30,7 +30,13 @@ export class SplunkLongTaskInstrumentation extends InstrumentationBase {
 		super(MODULE_NAME, VERSION, Object.assign({}, config))
 	}
 
-	init(): void {}
+	disable(): void {
+		if (!this.isSupported()) {
+			return
+		}
+
+		this._longtaskObserver.disconnect()
+	}
 
 	enable(): void {
 		if (!this.isSupported()) {
@@ -43,13 +49,7 @@ export class SplunkLongTaskInstrumentation extends InstrumentationBase {
 		this._longtaskObserver.observe({ type: LONGTASK_PERFORMANCE_TYPE, buffered: true })
 	}
 
-	disable(): void {
-		if (!this.isSupported()) {
-			return
-		}
-
-		this._longtaskObserver.disconnect()
-	}
+	init(): void {}
 
 	private _createSpanFromEntry(entry: PerformanceEntry) {
 		const span = this.tracer.startSpan(LONGTASK_PERFORMANCE_TYPE, {

--- a/packages/web/src/SplunkPageVisibilityInstrumentation.ts
+++ b/packages/web/src/SplunkPageVisibilityInstrumentation.ts
@@ -22,18 +22,21 @@ import { VERSION } from './version'
 const MODULE_NAME = 'splunk-visibility'
 
 export class SplunkPageVisibilityInstrumentation extends InstrumentationBase {
+	unloadListener: any
+
 	unloading: boolean
 
 	visibilityListener: any
-
-	unloadListener: any
 
 	constructor(config: InstrumentationConfig = {}) {
 		super(MODULE_NAME, VERSION, Object.assign({}, config))
 		this.unloading = false
 	}
 
-	init(): void {}
+	disable(): void {
+		window.removeEventListener('beforeunload', this.unloadListener)
+		window.removeEventListener('visibilitychange', this.visibilityListener)
+	}
 
 	enable(): void {
 		if (document.hidden) {
@@ -55,10 +58,7 @@ export class SplunkPageVisibilityInstrumentation extends InstrumentationBase {
 		window.addEventListener('visibilitychange', this.visibilityListener)
 	}
 
-	disable(): void {
-		window.removeEventListener('beforeunload', this.unloadListener)
-		window.removeEventListener('visibilitychange', this.visibilityListener)
-	}
+	init(): void {}
 
 	private _createSpan(hidden: boolean) {
 		const now = Date.now()

--- a/packages/web/src/SplunkSpanAttributesProcessor.ts
+++ b/packages/web/src/SplunkSpanAttributesProcessor.ts
@@ -27,22 +27,16 @@ export class SplunkSpanAttributesProcessor implements SpanProcessor {
 		this._globalAttributes = globalAttributes ?? {}
 	}
 
-	setGlobalAttributes(attributes?: Attributes): void {
-		if (attributes) {
-			Object.assign(this._globalAttributes, attributes)
-		} else {
-			for (const key of Object.keys(this._globalAttributes)) {
-				delete this._globalAttributes[key]
-			}
-		}
+	forceFlush(): Promise<void> {
+		return Promise.resolve()
 	}
 
 	getGlobalAttributes(): Attributes {
 		return this._globalAttributes
 	}
 
-	forceFlush(): Promise<void> {
-		return Promise.resolve()
+	onEnd(): void {
+		// Intentionally empty
 	}
 
 	onStart(span: Span): void {
@@ -52,8 +46,14 @@ export class SplunkSpanAttributesProcessor implements SpanProcessor {
 		span.setAttribute('browser.instance.visibility_state', document.visibilityState)
 	}
 
-	onEnd(): void {
-		// Intentionally empty
+	setGlobalAttributes(attributes?: Attributes): void {
+		if (attributes) {
+			Object.assign(this._globalAttributes, attributes)
+		} else {
+			for (const key of Object.keys(this._globalAttributes)) {
+				delete this._globalAttributes[key]
+			}
+		}
 	}
 
 	shutdown(): Promise<void> {

--- a/packages/web/src/SplunkUserInteractionInstrumentation.ts
+++ b/packages/web/src/SplunkUserInteractionInstrumentation.ts
@@ -72,9 +72,9 @@ type ExposedSuper = {
 }
 
 export class SplunkUserInteractionInstrumentation extends UserInteractionInstrumentation {
-	private _routingTracer: Tracer
-
 	private __hashChangeHandler: (ev: Event) => void
+
+	private _routingTracer: Tracer
 
 	constructor(config: SplunkUserInteractionInstrumentationConfig = {}) {
 		// Prefer otel's eventNames property
@@ -138,33 +138,6 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
 		}
 	}
 
-	setTracerProvider(tracerProvider: TracerProvider): void {
-		super.setTracerProvider(tracerProvider)
-		this._routingTracer = tracerProvider.getTracer(ROUTING_INSTRUMENTATION_NAME, ROUTING_INSTRUMENTATION_VERSION)
-	}
-
-	getZoneWithPrototype(): undefined {
-		// FIXME work out ngZone issues with Angular  PENDING
-		return undefined
-	}
-
-	enable(): void {
-		this.__hashChangeHandler = (event: Event) => {
-			this._emitRouteChangeSpan((event as HashChangeEvent).oldURL)
-		}
-
-		// Hash can be changed with location.hash = '#newThing', no way to hook that directly...
-		window.addEventListener('hashchange', this.__hashChangeHandler)
-
-		super.enable()
-	}
-
-	disable(): void {
-		super.disable()
-
-		window.removeEventListener('hashchange', this.__hashChangeHandler)
-	}
-
 	// FIXME find cleaner way to patch
 	_patchHistoryMethod(): (original: any) => (this: History, ...args: unknown[]) => any {
 		const that = this
@@ -179,6 +152,33 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
 
 				return result
 			}
+	}
+
+	disable(): void {
+		super.disable()
+
+		window.removeEventListener('hashchange', this.__hashChangeHandler)
+	}
+
+	enable(): void {
+		this.__hashChangeHandler = (event: Event) => {
+			this._emitRouteChangeSpan((event as HashChangeEvent).oldURL)
+		}
+
+		// Hash can be changed with location.hash = '#newThing', no way to hook that directly...
+		window.addEventListener('hashchange', this.__hashChangeHandler)
+
+		super.enable()
+	}
+
+	getZoneWithPrototype(): undefined {
+		// FIXME work out ngZone issues with Angular  PENDING
+		return undefined
+	}
+
+	setTracerProvider(tracerProvider: TracerProvider): void {
+		super.setTracerProvider(tracerProvider)
+		this._routingTracer = tracerProvider.getTracer(ROUTING_INSTRUMENTATION_NAME, ROUTING_INSTRUMENTATION_VERSION)
 	}
 
 	private _emitRouteChangeSpan(oldHref) {

--- a/packages/web/src/exporters/common.ts
+++ b/packages/web/src/exporters/common.ts
@@ -20,10 +20,10 @@ import { Attributes } from '@opentelemetry/api'
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base'
 
 export interface SplunkExporterConfig {
-	url: string
-	onAttributesSerializing?: (attributes: Attributes, span: ReadableSpan) => Attributes
-	xhrSender?: (url: string, data: string, headers?: Record<string, string>) => void
 	beaconSender?: (url: string, data: string, headers?: Record<string, string>) => void
+	onAttributesSerializing?: (attributes: Attributes, span: ReadableSpan) => Attributes
+	url: string
+	xhrSender?: (url: string, data: string, headers?: Record<string, string>) => void
 }
 
 export function NOOP_ATTRIBUTES_TRANSFORMER(attributes: Attributes): Attributes {

--- a/packages/web/src/exporters/otlp.ts
+++ b/packages/web/src/exporters/otlp.ts
@@ -22,12 +22,12 @@ import { NOOP_ATTRIBUTES_TRANSFORMER, NATIVE_XHR_SENDER, NATIVE_BEACON_SENDER, S
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base'
 
 export class SplunkOTLPTraceExporter extends OTLPTraceExporter {
+	protected readonly _beaconSender: SplunkExporterConfig['beaconSender'] =
+		typeof navigator !== 'undefined' && navigator.sendBeacon ? NATIVE_BEACON_SENDER : undefined
+
 	protected readonly _onAttributesSerializing: SplunkExporterConfig['onAttributesSerializing']
 
 	protected readonly _xhrSender: SplunkExporterConfig['xhrSender'] = NATIVE_XHR_SENDER
-
-	protected readonly _beaconSender: SplunkExporterConfig['beaconSender'] =
-		typeof navigator !== 'undefined' && navigator.sendBeacon ? NATIVE_BEACON_SENDER : undefined
 
 	constructor(options: SplunkExporterConfig) {
 		super(options)

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -82,15 +82,15 @@ export * from './SplunkWebTracerProvider'
 export * from './SessionBasedSampler'
 
 interface SplunkOtelWebOptionsInstrumentations {
+	connectivity?: boolean | InstrumentationConfig
 	document?: boolean | InstrumentationConfig
 	errors?: boolean
 	fetch?: boolean | FetchInstrumentationConfig
 	interactions?: boolean | SplunkUserInteractionInstrumentationConfig
 	longtask?: boolean | InstrumentationConfig
-	visibility?: boolean | InstrumentationConfig
-	connectivity?: boolean | InstrumentationConfig
 	postload?: boolean | SplunkPostDocLoadResourceInstrumentationConfig
 	socketio?: boolean | SocketIoClientInstrumentationConfig
+	visibility?: boolean | InstrumentationConfig
 	websocket?: boolean | InstrumentationConfig
 	webvitals?: boolean | WebVitalsInstrumentationConfig
 	xhr?: boolean | XMLHttpRequestInstrumentationConfig
@@ -110,6 +110,11 @@ export interface SplunkOtelWebExporterOptions {
 }
 
 export interface SplunkOtelWebConfig {
+	/**
+	 * If enabled, all spans are treated as activity and extend the duration of the session. Defaults to false.
+	 */
+	_experimental_allSpansExtendSession?: boolean
+
 	/** Allows http beacon urls */
 	allowInsecureBeacon?: boolean
 
@@ -121,14 +126,14 @@ export interface SplunkOtelWebConfig {
 	/** Application name */
 	applicationName?: string
 
+	/** Destination for the captured data */
+	beaconEndpoint?: string
+
 	/**
 	 * Destination for the captured data
 	 * @deprecated Renamed to `beaconEndpoint`, or use realm
 	 */
 	beaconUrl?: string
-
-	/** Destination for the captured data */
-	beaconEndpoint?: string
 
 	/** Options for context manager */
 	context?: ContextManagerConfig
@@ -149,11 +154,6 @@ export interface SplunkOtelWebConfig {
 	 * @deprecated Renamed to `deploymentEnvironment`
 	 */
 	environment?: string
-
-	/**
-	 * Sets a value for the 'app.version' attribute
-	 */
-	version?: string
 
 	/** Allows configuring how telemetry data is sent to the backend */
 	exporter?: SplunkOtelWebExporterOptions
@@ -176,6 +176,12 @@ export interface SplunkOtelWebConfig {
 	realm?: string
 
 	/**
+	 * Publicly-visible rum access token value. Please do not paste any other access token or auth value into here, as this
+	 * will be visible to every user of your app
+	 */
+	rumAccessToken?: string
+
+	/**
 	 * Publicly-visible `rumAuth` value.  Please do not paste any other access token or auth value into here, as this
 	 * will be visible to every user of your app
 	 * @deprecated Renamed to rumAccessToken
@@ -183,20 +189,14 @@ export interface SplunkOtelWebConfig {
 	rumAuth?: string
 
 	/**
-	 * Publicly-visible rum access token value. Please do not paste any other access token or auth value into here, as this
-	 * will be visible to every user of your app
-	 */
-	rumAccessToken?: string
-
-	/**
 	 * Config options passed to web tracer
 	 */
 	tracer?: WebTracerConfig
 
 	/**
-	 * If enabled, all spans are treated as activity and extend the duration of the session. Defaults to false.
+	 * Sets a value for the 'app.version' attribute
 	 */
-	_experimental_allSpansExtendSession?: boolean
+	version?: string
 }
 
 interface SplunkOtelWebConfigInternal extends SplunkOtelWebConfig {
@@ -299,52 +299,55 @@ function buildExporter(options: SplunkOtelWebConfigInternal) {
 }
 
 export interface SplunkOtelWebType extends SplunkOtelWebEventTarget {
-	readonly resource?: Resource
+	AlwaysOffSampler: typeof AlwaysOffSampler
+	AlwaysOnSampler: typeof AlwaysOnSampler
 
-	deinit: (force?: boolean) => void
+	DEFAULT_AUTO_INSTRUMENTED_EVENTS: UserInteractionEventsConfig
+	DEFAULT_AUTO_INSTRUMENTED_EVENT_NAMES: (keyof HTMLElementEventMap)[]
 
-	error: (...args: Array<any>) => void
+	ParentBasedSampler: typeof ParentBasedSampler
+	SessionBasedSampler: typeof SessionBasedSampler
 
-	init: (options: SplunkOtelWebConfig) => void
-
-	/**
-	 * Allows experimental options to be passed. No versioning guarantees are given for this method.
-	 */
-	_internalInit: (options: Partial<SplunkOtelWebConfigInternal>) => void
-
-	provider?: SplunkWebTracerProvider
-
-	attributesProcessor?: SplunkSpanAttributesProcessor
-
-	setGlobalAttributes: (attributes: Attributes) => void
-
-	/**
-	 * This method provides access to computed, final value of global attributes, which are applied to all created spans.
-	 */
-	getGlobalAttributes: () => Attributes
 	/**
 	 * @deprecated Use {@link getGlobalAttributes()}
 	 */
 	_experimental_getGlobalAttributes: () => Attributes
 
 	/**
-	 * This method returns current session ID
-	 */
-	getSessionId: () => SessionIdType | undefined
-	/**
 	 * @deprecated Use {@link getSessionId()}
 	 */
 	_experimental_getSessionId: () => SessionIdType | undefined
 
-	DEFAULT_AUTO_INSTRUMENTED_EVENTS: UserInteractionEventsConfig
-	DEFAULT_AUTO_INSTRUMENTED_EVENT_NAMES: (keyof HTMLElementEventMap)[]
+	/**
+	 * Allows experimental options to be passed. No versioning guarantees are given for this method.
+	 */
+	_internalInit: (options: Partial<SplunkOtelWebConfigInternal>) => void
 
-	AlwaysOnSampler: typeof AlwaysOnSampler
-	AlwaysOffSampler: typeof AlwaysOffSampler
-	ParentBasedSampler: typeof ParentBasedSampler
-	SessionBasedSampler: typeof SessionBasedSampler
+	attributesProcessor?: SplunkSpanAttributesProcessor
+
+	deinit: (force?: boolean) => void
+
+	error: (...args: Array<any>) => void
+
+	/**
+	 * This method provides access to computed, final value of global attributes, which are applied to all created spans.
+	 */
+	getGlobalAttributes: () => Attributes
+
+	/**
+	 * This method returns current session ID
+	 */
+	getSessionId: () => SessionIdType | undefined
+
+	init: (options: SplunkOtelWebConfig) => void
 
 	readonly inited: boolean
+
+	provider?: SplunkWebTracerProvider
+
+	readonly resource?: Resource
+
+	setGlobalAttributes: (attributes: Attributes) => void
 }
 
 let inited = false

--- a/packages/web/src/session.ts
+++ b/packages/web/src/session.ts
@@ -156,11 +156,11 @@ class ActivitySpanProcessor implements SpanProcessor {
 		return Promise.resolve()
 	}
 
+	onEnd(): void {}
+
 	onStart(): void {
 		markActivity()
 	}
-
-	onEnd(): void {}
 
 	shutdown(): Promise<void> {
 		return Promise.resolve()

--- a/packages/web/test/SplunkExporter.test.ts
+++ b/packages/web/test/SplunkExporter.test.ts
@@ -39,7 +39,7 @@ function buildDummySpan({ name = '<name>', attributes = {} } = {}) {
 		duration: timeInputToHrTime(1000),
 		status: { code: api.SpanStatusCode.UNSET },
 		resource: { attributes: {} },
-		events: [] as { time: api.HrTime; name: string }[],
+		events: [] as { name: string; time: api.HrTime }[],
 	} as ReadableSpan
 }
 

--- a/packages/web/test/utils.ts
+++ b/packages/web/test/utils.ts
@@ -24,13 +24,11 @@ import { assert } from 'chai'
 export class SpanCapturer implements SpanProcessor {
 	public readonly spans: ReadableSpan[] = []
 
-	forceFlush(): Promise<void> {
-		return Promise.resolve()
+	clear(): void {
+		this.spans.length = 0
 	}
 
-	onStart(): void {}
-
-	shutdown(): Promise<void> {
+	forceFlush(): Promise<void> {
 		return Promise.resolve()
 	}
 
@@ -38,8 +36,10 @@ export class SpanCapturer implements SpanProcessor {
 		this.spans.push(span)
 	}
 
-	clear(): void {
-		this.spans.length = 0
+	onStart(): void {}
+
+	shutdown(): Promise<void> {
+		return Promise.resolve()
 	}
 }
 


### PR DESCRIPTION
# Description

This PR introduces deterministic sorting for classes and interfaces to improve consistency in the structure of our codebase. By sorting members in a predefined order, we can reduce noise in diffs, especially when additional properties or members are added over time. This change ensures that new members will not disrupt the overall order, resulting in smaller diffs.

## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)


# How has this been tested?

Just sorting. No need to create tests.

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
