### PR TITLE
fix(session-replay): id increment

### DIFF
--- a/examples/next-ssr-example/README.md
+++ b/examples/next-ssr-example/README.md
@@ -4,7 +4,7 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped using [`create-nex
 
 ## Instrumenting with Splunk RUM using NPM installation method
 
-Next.js uses [static generation](https://nextjs.org/docs/basic-features/pages#pre-rendering) by default to generate the output HTML for most pages. As static generation is done using the node.js runtime, it isn't compatible with RUM. Check that RUM is only imported and activated in the browser environment.
+Next.js uses static generation by default to generate the output HTML for most pages. As static generation is done using the node.js runtime, it isn't compatible with RUM. Check that RUM is only imported and activated in the browser environment.
 
 1. Install Splunk RUM for Browser: `npm install @splunk/otel-web --save`
 2. Create file `src/instrument.js` that imports `@splunk/otel-web` and calls `SplunkOtelWeb.init()`. You can use the Data Setup guided setup in Splunk Observability to get the correct values for your organization.

--- a/packages/session-recorder/src/index.ts
+++ b/packages/session-recorder/src/index.ts
@@ -215,8 +215,9 @@ const SplunkRumRecorder = {
 				}
 
 				const time = event.timestamp
-				eventCounter += 1
 				const eventI = eventCounter
+				eventCounter += 1
+
 				// Research found that stringifying the rr-web event here is
 				// more efficient for otlp + gzip exporting
 
@@ -226,13 +227,13 @@ const SplunkRumRecorder = {
 				for (let i = 0; i < totalC; i++) {
 					const start = i * MAX_CHUNK_SIZE
 					const end = (i + 1) * MAX_CHUNK_SIZE
-					logCounter += 1
 					const log = convert(decoder.decode(body.slice(start, end)), time, {
 						'rr-web.offset': logCounter,
 						'rr-web.event': eventI,
 						'rr-web.chunk': i + 1,
 						'rr-web.total-chunks': totalC,
 					})
+					logCounter += 1
 					if (debug) {
 						console.log(log)
 					}


### PR DESCRIPTION
# Description

Fix bug introduced by the eslint update in #879. Previously, the `++` operator was used, which increments the value after the variable is accessed. We switched to `+=` and moved it before the variable is used, causing issues with the indices.

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Delete options that are not relevant.

- Manual testing

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
