### PR TITLE
feat: add option to save session data to local storage

### DIFF
--- a/packages/web/src/cookie-session.ts
+++ b/packages/web/src/cookie-session.ts
@@ -1,0 +1,124 @@
+/**
+ *
+ * Copyright 2024 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { isIframe } from './utils'
+import { SessionState } from './types'
+
+export const COOKIE_NAME = '_splunk_rum_sid'
+
+const CookieSession = 4 * 60 * 60 * 1000 // 4 hours
+const InactivityTimeoutSeconds = 15 * 60
+
+export const cookieStore = {
+	set: (value: string): void => {
+		document.cookie = value
+	},
+	get: (): string => document.cookie,
+}
+
+export function parseCookieToSessionState(): SessionState | undefined {
+	const rawValue = findCookieValue(COOKIE_NAME)
+	if (!rawValue) {
+		return undefined
+	}
+
+	const decoded = decodeURIComponent(rawValue)
+	if (!decoded) {
+		return undefined
+	}
+
+	let sessionState: unknown = undefined
+	try {
+		sessionState = JSON.parse(decoded)
+	} catch {
+		return undefined
+	}
+
+	if (!isSessionState(sessionState)) {
+		return undefined
+	}
+
+	// id validity
+	if (
+		!sessionState.id ||
+		typeof sessionState.id !== 'string' ||
+		!sessionState.id.length ||
+		sessionState.id.length !== 32
+	) {
+		return undefined
+	}
+
+	// startTime validity
+	if (!sessionState.startTime || typeof sessionState.startTime !== 'number' || isPastMaxAge(sessionState.startTime)) {
+		return undefined
+	}
+
+	return sessionState
+}
+
+export function renewCookieTimeout(sessionState: SessionState, cookieDomain: string | undefined): void {
+	if (isPastMaxAge(sessionState.startTime)) {
+		// safety valve
+		return
+	}
+
+	const cookieValue = encodeURIComponent(JSON.stringify(sessionState))
+	const domain = cookieDomain ? `domain=${cookieDomain};` : ''
+	let cookie = COOKIE_NAME + '=' + cookieValue + '; path=/;' + domain + 'max-age=' + InactivityTimeoutSeconds
+
+	if (isIframe()) {
+		cookie += ';SameSite=None; Secure'
+	} else {
+		cookie += ';SameSite=Strict'
+	}
+
+	cookieStore.set(cookie)
+}
+
+export function clearSessionCookie(cookieDomain?: string): void {
+	const domain = cookieDomain ? `domain=${cookieDomain};` : ''
+	const cookie = `${COOKIE_NAME}=;domain=${domain};expires=Thu, 01 Jan 1970 00:00:00 GMT`
+	cookieStore.set(cookie)
+}
+
+export function findCookieValue(cookieName: string): string | undefined {
+	const decodedCookie = decodeURIComponent(cookieStore.get())
+	const cookies = decodedCookie.split(';')
+	for (let i = 0; i < cookies.length; i++) {
+		const c = cookies[i].trim()
+		if (c.indexOf(cookieName + '=') === 0) {
+			return c.substring((cookieName + '=').length, c.length)
+		}
+	}
+	return undefined
+}
+
+function isPastMaxAge(startTime: number): boolean {
+	const now = Date.now()
+	return startTime > now || now > startTime + CookieSession
+}
+
+function isSessionState(maybeSessionState: unknown): maybeSessionState is SessionState {
+	return (
+		typeof maybeSessionState === 'object' &&
+		maybeSessionState !== null &&
+		'id' in maybeSessionState &&
+		typeof maybeSessionState['id'] === 'string' &&
+		'startTime' in maybeSessionState &&
+		typeof maybeSessionState['startTime'] === 'number'
+	)
+}

--- a/packages/web/src/local-storage-session.ts
+++ b/packages/web/src/local-storage-session.ts
@@ -1,0 +1,56 @@
+/**
+ *
+ * Copyright 2024 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { SessionState } from './types'
+import { safelyGetLocalStorage, safelySetLocalStorage } from './utils/storage'
+
+const SESSION_ID_LENGTH = 32
+const SESSION_DURATION_MS = 4 * 60 * 60 * 1000 // 4 hours
+
+const SESSION_ID_KEY = '_SPLUNK_SESSION_ID'
+const SESSION_LAST_UPDATED_KEY = '_SPLUNK_SESSION_LAST_UPDATED'
+
+export const getSessionStateFromLocalStorage = (): SessionState | undefined => {
+	const sessionId = safelyGetLocalStorage(SESSION_ID_KEY)
+	if (!isSessionIdValid(sessionId)) {
+		return
+	}
+
+	const startTimeString = safelyGetLocalStorage(SESSION_LAST_UPDATED_KEY)
+	const startTime = Number.parseInt(startTimeString, 10)
+	if (!isSessionStartTimeValid(startTime) || isSessionExpired(startTime)) {
+		return
+	}
+
+	return { id: sessionId, startTime }
+}
+
+export const setSessionStateToLocalStorage = (sessionState: SessionState): void => {
+	if (isSessionExpired(sessionState.startTime)) {
+		return
+	}
+
+	safelySetLocalStorage(SESSION_ID_KEY, sessionState.id)
+	safelySetLocalStorage(SESSION_LAST_UPDATED_KEY, String(sessionState.startTime))
+}
+
+const isSessionIdValid = (sessionId: unknown): boolean =>
+	typeof sessionId === 'string' && sessionId.length === SESSION_ID_LENGTH
+
+const isSessionStartTimeValid = (startTime: unknown): boolean => typeof startTime === 'number' && startTime < Date.now()
+
+const isSessionExpired = (startTime: number) => Date.now() - startTime > SESSION_DURATION_MS

--- a/packages/web/src/local-storage-session.ts
+++ b/packages/web/src/local-storage-session.ts
@@ -16,7 +16,7 @@
  *
  */
 import { SessionState } from './types'
-import { safelyGetLocalStorage, safelySetLocalStorage } from './utils/storage'
+import { safelyGetLocalStorage, safelySetLocalStorage, safelyRemoveFromLocalStorage } from './utils/storage'
 
 const SESSION_ID_LENGTH = 32
 const SESSION_DURATION_MS = 4 * 60 * 60 * 1000 // 4 hours
@@ -48,9 +48,15 @@ export const setSessionStateToLocalStorage = (sessionState: SessionState): void 
 	safelySetLocalStorage(SESSION_LAST_UPDATED_KEY, String(sessionState.startTime))
 }
 
+export const clearSessionStateFromLocalStorage = (): void => {
+	safelyRemoveFromLocalStorage(SESSION_ID_KEY)
+	safelyRemoveFromLocalStorage(SESSION_LAST_UPDATED_KEY)
+}
+
 const isSessionIdValid = (sessionId: unknown): boolean =>
 	typeof sessionId === 'string' && sessionId.length === SESSION_ID_LENGTH
 
-const isSessionStartTimeValid = (startTime: unknown): boolean => typeof startTime === 'number' && startTime < Date.now()
+const isSessionStartTimeValid = (startTime: unknown): boolean =>
+	typeof startTime === 'number' && startTime <= Date.now()
 
 const isSessionExpired = (startTime: number) => Date.now() - startTime > SESSION_DURATION_MS

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -1,0 +1,23 @@
+/**
+ *
+ * Copyright 2024 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+export type SessionId = string
+
+export type SessionState = {
+	id: SessionId
+	startTime: number
+}

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -25,25 +25,6 @@ export function generateId(bits: number): string {
 	})
 }
 
-export const cookieStore = {
-	set: (value: string): void => {
-		document.cookie = value
-	},
-	get: (): string => document.cookie,
-}
-
-export function findCookieValue(cookieName: string): string | undefined {
-	const decodedCookie = decodeURIComponent(cookieStore.get())
-	const cookies = decodedCookie.split(';')
-	for (let i = 0; i < cookies.length; i++) {
-		const c = cookies[i].trim()
-		if (c.indexOf(cookieName + '=') === 0) {
-			return c.substring((cookieName + '=').length, c.length)
-		}
-	}
-	return undefined
-}
-
 export function limitLen(s: string, cap: number): string {
 	if (s.length > cap) {
 		return s.substring(0, cap)

--- a/packages/web/src/utils/storage.ts
+++ b/packages/web/src/utils/storage.ts
@@ -15,6 +15,36 @@
  * limitations under the License.
  *
  */
+export const safelyGetLocalStorage = (key: string): string | null => {
+	let value = null
+	try {
+		value = window.localStorage.getItem(key)
+	} catch {
+		// localStorage not accessible probably user is in incognito-mode
+		// or set "Block third-party cookies" option in browser settings
+	}
+	return value
+}
+
+export const safelySetLocalStorage = (key: string, value: string): boolean => {
+	try {
+		window.localStorage.setItem(key, value)
+		return true
+	} catch {
+		// localStorage not accessible probably user is in incognito-mode
+		// or set "Block third-party cookies" option in browser settings
+		return false
+	}
+}
+
+export const safelyRemoveFromLocalStorage = (key: string): void => {
+	try {
+		window.localStorage.removeItem(key)
+	} catch {
+		// localStorage not accessible probably user is in incognito-mode
+		// or set "Block third-party cookies" option in browser settings
+	}
+}
 
 export const safelyGetSessionStorage = (key: string): string | null | undefined => {
 	try {

--- a/packages/web/test/SessionBasedSampler.test.ts
+++ b/packages/web/test/SessionBasedSampler.test.ts
@@ -19,9 +19,10 @@
 import * as assert from 'assert'
 import { InternalEventTarget } from '../src/EventTarget'
 import { SessionBasedSampler } from '../src/SessionBasedSampler'
-import { initSessionTracking, COOKIE_NAME, updateSessionStatus } from '../src/session'
+import { initSessionTracking, updateSessionStatus } from '../src/session'
 import { context, SamplingDecision } from '@opentelemetry/api'
 import { SplunkWebTracerProvider } from '../src'
+import { COOKIE_NAME } from '../src/cookie-session'
 
 describe('Session based sampler', () => {
 	it('decide sampling based on session id and ratio', () => {

--- a/packages/web/test/session.test.ts
+++ b/packages/web/test/session.test.ts
@@ -18,16 +18,10 @@
 
 import * as assert from 'assert'
 import { InternalEventTarget } from '../src/EventTarget'
-import {
-	initSessionTracking,
-	COOKIE_NAME,
-	getRumSessionId,
-	updateSessionStatus,
-	clearSessionCookie,
-} from '../src/session'
+import { initSessionTracking, getRumSessionId, updateSessionStatus } from '../src/session'
 import { SplunkWebTracerProvider } from '../src'
 import sinon from 'sinon'
-import { cookieStore } from '../src/utils'
+import { COOKIE_NAME, clearSessionCookie, cookieStore } from '../src/cookie-session'
 
 describe('Session tracking', () => {
 	beforeEach(() => {

--- a/packages/web/test/session.test.ts
+++ b/packages/web/test/session.test.ts
@@ -22,6 +22,7 @@ import { initSessionTracking, getRumSessionId, updateSessionStatus } from '../sr
 import { SplunkWebTracerProvider } from '../src'
 import sinon from 'sinon'
 import { COOKIE_NAME, clearSessionCookie, cookieStore } from '../src/cookie-session'
+import { clearSessionStateFromLocalStorage } from '../src/local-storage-session'
 
 describe('Session tracking', () => {
 	beforeEach(() => {
@@ -102,5 +103,34 @@ describe('Session tracking', () => {
 			assert.equal(cookieSetSpy.callCount, 2)
 			done()
 		})
+	})
+})
+
+describe('Session tracking - localStorage', () => {
+	beforeEach(() => {
+		clearSessionStateFromLocalStorage()
+	})
+
+	afterEach(() => {
+		clearSessionStateFromLocalStorage()
+	})
+
+	it('should save session state to local storage', () => {
+		const useLocalStorage = true
+		const provider = new SplunkWebTracerProvider()
+		const trackingHandle = initSessionTracking(
+			provider,
+			'1234',
+			new InternalEventTarget(),
+			undefined,
+			undefined,
+			useLocalStorage,
+		)
+
+		const firstSessionId = getRumSessionId()
+		updateSessionStatus(useLocalStorage)
+		assert.strictEqual(firstSessionId, getRumSessionId())
+
+		trackingHandle.deinit()
 	})
 })

--- a/packages/web/test/utils.test.ts
+++ b/packages/web/test/utils.test.ts
@@ -17,7 +17,8 @@
  */
 
 import * as assert from 'assert'
-import { findCookieValue, generateId } from '../src/utils'
+import { generateId } from '../src/utils'
+import { findCookieValue } from '../src/cookie-session'
 
 describe('generateId', () => {
 	it('should generate IDs of 64 and 128 bits', () => {


### PR DESCRIPTION
# Description

Added `init` config option `useLocalStorage` to save session data to local storage instead of cookie. It's mandatory for environments where cookie isn't usable, like Electron apps.

_List Github issue(s) which this PR fixes._

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
