### PR TITLE
feat: add `persistence` flag

### DIFF
--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -297,6 +297,13 @@ export const SplunkRum: SplunkOtelWebType = {
 			},
 		)
 
+		if (!['localStorage', 'cookie', undefined].includes(processedOptions.persistence)) {
+			diag.error(
+				'Invalid persistence flag: The value for "persistence" must be either "cookie", "localStorage", or omitted entirely.',
+			)
+			return
+		}
+
 		this._processedOptions = processedOptions
 
 		if (processedOptions.realm) {
@@ -359,7 +366,7 @@ export const SplunkRum: SplunkOtelWebType = {
 			eventTarget,
 			processedOptions.cookieDomain,
 			!!options._experimental_allSpansExtendSession,
-			processedOptions.useLocalStorage,
+			processedOptions.persistence === 'localStorage',
 		).deinit
 
 		const instrumentations = INSTRUMENTATIONS.map(({ Instrument, confKey, disable }) => {
@@ -523,7 +530,7 @@ export const SplunkRum: SplunkOtelWebType = {
 
 		updateSessionStatus({
 			forceStore: false,
-			useLocalStorage: this._processedOptions.useLocalStorage ?? false,
+			useLocalStorage: this._processedOptions.persistence === 'localStorage',
 			forceActivity: this._processedOptions._experimental_allSpansExtendSession,
 		})
 	},

--- a/packages/web/src/types/config.ts
+++ b/packages/web/src/types/config.ts
@@ -128,6 +128,18 @@ export interface SplunkOtelWebConfig {
 	instrumentations?: SplunkOtelWebOptionsInstrumentations
 
 	/**
+	 * Specifies where session data should be stored.
+	 *
+	 * Available options:
+	 * - `'cookie'` (default): Session data will be stored in a browser cookie.
+	 *
+	 * - `'localStorage'`: Session data will be stored in the browser's localStorage.
+	 *
+	 * If not specified, `'cookie'` will be used as the default storage method.
+	 */
+	persistence?: 'cookie' | 'localStorage'
+
+	/**
 	 * The name of your organization’s realm. Automatically configures beaconUrl with correct URL
 	 */
 	realm?: string
@@ -149,9 +161,6 @@ export interface SplunkOtelWebConfig {
 	 * Config options passed to web tracer
 	 */
 	tracer?: WebTracerConfig
-
-	/** Use local storage to save session ID instead of cookie */
-	useLocalStorage?: boolean
 
 	/**
 	 * Sets a value for the 'app.version' attribute


### PR DESCRIPTION
# Description

Added persistence flag

Available options:
- `'cookie'` (default): Session state will be stored in a browser cookie.
- `'localStorage'`: Session state will be stored in the browser's localStorage.

If not specified, `'cookie'` will be used as the default storage method.

## Type of change


- New feature (non-breaking change which adds functionality)

# How has this been tested?

Delete options that are not relevant.

- Manual testing

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
