### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
               run: npm run test:integration:local:${{ matrix.browser }}:_execute
 
             - name: Upload test logs
-              uses: actions/upload-artifact@v3.1.2
+              uses: actions/upload-artifact@v4
               if: ${{ failure() }}
               with:
                   name: test-results ${{ matrix.browser }}


### PR DESCRIPTION
actions/upload-artifact@v3 is going away in Jan and will break builds. Update it to v4.