### PR TITLE
chore(internal): update license headers to reflect 2025

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/LICENSE
+++ b/LICENSE
@@ -174,29 +174,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -52,13 +52,13 @@ export default [
 					source: 'string',
 					content: [
 						'',
-						`Copyright ${new Date().getFullYear()} Splunk Inc.`,
+						`Copyright 2020-${new Date().getFullYear()} Splunk Inc.`,
 						'',
 						'Licensed under the Apache License, Version 2.0 (the "License");',
 						'you may not use this file except in compliance with the License.',
 						'You may obtain a copy of the License at',
 						'',
-						'http://www.apache.org/licenses/LICENSE-2.0',
+						'https://www.apache.org/licenses/LICENSE-2.0',
 						'',
 						'Unless required by applicable law or agreed to in writing, software',
 						'distributed under the License is distributed on an "AS IS" BASIS,',

--- a/examples/todolist/server/index.mjs
+++ b/examples/todolist/server/index.mjs
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/todolist/server/instrumentation.mjs
+++ b/examples/todolist/server/instrumentation.mjs
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/todolist/src/App.js
+++ b/examples/todolist/src/App.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/todolist/src/TodoAdd.jsx
+++ b/examples/todolist/src/TodoAdd.jsx
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/todolist/src/TodoEdit.jsx
+++ b/examples/todolist/src/TodoEdit.jsx
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/todolist/src/TodoList.jsx
+++ b/examples/todolist/src/TodoList.jsx
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/todolist/src/TodoRow.jsx
+++ b/examples/todolist/src/TodoRow.jsx
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/todolist/src/index.js
+++ b/examples/todolist/src/index.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/playwright.config.ts
+++ b/packages/integration-tests/playwright.config.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/pages/record-page.ts
+++ b/packages/integration-tests/src/pages/record-page.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/server/middlewares/delay-middleware.ts
+++ b/packages/integration-tests/src/server/middlewares/delay-middleware.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/server/middlewares/index.ts
+++ b/packages/integration-tests/src/server/middlewares/index.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/server/middlewares/no-cache-middleware.ts
+++ b/packages/integration-tests/src/server/middlewares/no-cache-middleware.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/server/middlewares/server-timing-middleware.ts
+++ b/packages/integration-tests/src/server/middlewares/server-timing-middleware.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/server/render-agent.ts
+++ b/packages/integration-tests/src/server/render-agent.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/server/server-socketio.ts
+++ b/packages/integration-tests/src/server/server-socketio.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/server/server-timing.ts
+++ b/packages/integration-tests/src/server/server-timing.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/server/server.ts
+++ b/packages/integration-tests/src/server/server.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/cdn/index.spec.ts
+++ b/packages/integration-tests/src/tests/cdn/index.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/connectivity/connectivity.spec.ts
+++ b/packages/integration-tests/src/tests/connectivity/connectivity.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/context/async-context.spec.ts
+++ b/packages/integration-tests/src/tests/context/async-context.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/context/framework/framework.spec.ts
+++ b/packages/integration-tests/src/tests/context/framework/framework.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/cookies/cookies.spec.ts
+++ b/packages/integration-tests/src/tests/cookies/cookies.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/docload/docload.spec.ts
+++ b/packages/integration-tests/src/tests/docload/docload.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/errors/errors.spec.ts
+++ b/packages/integration-tests/src/tests/errors/errors.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/errors/views/script1.min.js
+++ b/packages/integration-tests/src/tests/errors/views/script1.min.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/errors/views/script2.min.js
+++ b/packages/integration-tests/src/tests/errors/views/script2.min.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/fetch/fetch.spec.ts
+++ b/packages/integration-tests/src/tests/fetch/fetch.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/init/init.spec.ts
+++ b/packages/integration-tests/src/tests/init/init.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/long-task/long-task.spec.ts
+++ b/packages/integration-tests/src/tests/long-task/long-task.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/native/native.spec.ts
+++ b/packages/integration-tests/src/tests/native/native.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/redacting-attributes/index.spec.ts
+++ b/packages/integration-tests/src/tests/redacting-attributes/index.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/resource-observer/assets/test-alt.js
+++ b/packages/integration-tests/src/tests/resource-observer/assets/test-alt.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/resource-observer/assets/test.js
+++ b/packages/integration-tests/src/tests/resource-observer/assets/test.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/resource-observer/resource-observer.spec.ts
+++ b/packages/integration-tests/src/tests/resource-observer/resource-observer.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/server-timing/index.spec.ts
+++ b/packages/integration-tests/src/tests/server-timing/index.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/socketio/socketio.spec.ts
+++ b/packages/integration-tests/src/tests/socketio/socketio.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/synthetics/synthetics.spec.ts
+++ b/packages/integration-tests/src/tests/synthetics/synthetics.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/user-interaction/causality.spec.ts
+++ b/packages/integration-tests/src/tests/user-interaction/causality.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/user-interaction/forms.spec.ts
+++ b/packages/integration-tests/src/tests/user-interaction/forms.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/user-interaction/history.spec.ts
+++ b/packages/integration-tests/src/tests/user-interaction/history.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/user-interaction/keyboard.spec.ts
+++ b/packages/integration-tests/src/tests/user-interaction/keyboard.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/user-interaction/mouse.spec.ts
+++ b/packages/integration-tests/src/tests/user-interaction/mouse.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/visibility/visibility.spec.ts
+++ b/packages/integration-tests/src/tests/visibility/visibility.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/websocket/websocket.spec.ts
+++ b/packages/integration-tests/src/tests/websocket/websocket.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/webvitals/webvitals.spec.ts
+++ b/packages/integration-tests/src/tests/webvitals/webvitals.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/tests/xhr/xhr.spec.ts
+++ b/packages/integration-tests/src/tests/xhr/xhr.spec.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/utils/test.ts
+++ b/packages/integration-tests/src/utils/test.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/utils/time-make-sense.ts
+++ b/packages/integration-tests/src/utils/time-make-sense.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/integration-tests/src/version.ts
+++ b/packages/integration-tests/src/version.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/session-recorder/rollup.config.mjs
+++ b/packages/session-recorder/rollup.config.mjs
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/session-recorder/src/BatchLogProcessor.ts
+++ b/packages/session-recorder/src/BatchLogProcessor.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/session-recorder/src/OTLPLogExporter.ts
+++ b/packages/session-recorder/src/OTLPLogExporter.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/session-recorder/src/index.ts
+++ b/packages/session-recorder/src/index.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/session-recorder/src/types.ts
+++ b/packages/session-recorder/src/types.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/session-recorder/src/utils.ts
+++ b/packages/session-recorder/src/utils.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/session-recorder/src/version.ts
+++ b/packages/session-recorder/src/version.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/karma.conf.js
+++ b/packages/web/karma.conf.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/performance-tests/devServer/devServer.js
+++ b/packages/web/performance-tests/devServer/devServer.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/performance-tests/devServer/randomImageProvider.js
+++ b/packages/web/performance-tests/devServer/randomImageProvider.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/performance-tests/devServer/reactBundleProvider.js
+++ b/packages/web/performance-tests/devServer/reactBundleProvider.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/performance-tests/devServer/splunkRumProvider.js
+++ b/packages/web/performance-tests/devServer/splunkRumProvider.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/performance-tests/injectingProxy/HtmlInjectorTransform.js
+++ b/packages/web/performance-tests/injectingProxy/HtmlInjectorTransform.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/performance-tests/injectingProxy/server.js
+++ b/packages/web/performance-tests/injectingProxy/server.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/performance-tests/runner.js
+++ b/packages/web/performance-tests/runner.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/performance-tests/takeResultsFromReport.js
+++ b/packages/web/performance-tests/takeResultsFromReport.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/rollup.config.mjs
+++ b/packages/web/rollup.config.mjs
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/EventTarget.ts
+++ b/packages/web/src/EventTarget.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/SessionBasedSampler.ts
+++ b/packages/web/src/SessionBasedSampler.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/SplunkConnectivityInstrumentation.ts
+++ b/packages/web/src/SplunkConnectivityInstrumentation.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/SplunkContextManager.ts
+++ b/packages/web/src/SplunkContextManager.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/SplunkDocumentLoadInstrumentation.ts
+++ b/packages/web/src/SplunkDocumentLoadInstrumentation.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/SplunkErrorInstrumentation.ts
+++ b/packages/web/src/SplunkErrorInstrumentation.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/SplunkFetchInstrumentation.ts
+++ b/packages/web/src/SplunkFetchInstrumentation.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/SplunkLongTaskInstrumentation.ts
+++ b/packages/web/src/SplunkLongTaskInstrumentation.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/SplunkPageVisibilityInstrumentation.ts
+++ b/packages/web/src/SplunkPageVisibilityInstrumentation.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/SplunkPostDocLoadResourceInstrumentation.ts
+++ b/packages/web/src/SplunkPostDocLoadResourceInstrumentation.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/SplunkSocketIoClientInstrumentation.ts
+++ b/packages/web/src/SplunkSocketIoClientInstrumentation.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/SplunkSpanAttributesProcessor.ts
+++ b/packages/web/src/SplunkSpanAttributesProcessor.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/SplunkUserInteractionInstrumentation.ts
+++ b/packages/web/src/SplunkUserInteractionInstrumentation.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/SplunkWebSocketInstrumentation.ts
+++ b/packages/web/src/SplunkWebSocketInstrumentation.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/SplunkWebTracerProvider.ts
+++ b/packages/web/src/SplunkWebTracerProvider.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/SplunkXhrPlugin.ts
+++ b/packages/web/src/SplunkXhrPlugin.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/exporters/common.ts
+++ b/packages/web/src/exporters/common.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/exporters/otlp.ts
+++ b/packages/web/src/exporters/otlp.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/exporters/rate-limit.ts
+++ b/packages/web/src/exporters/rate-limit.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/exporters/zipkin.ts
+++ b/packages/web/src/exporters/zipkin.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/global-utils.ts
+++ b/packages/web/src/global-utils.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/indexBrowser.ts
+++ b/packages/web/src/indexBrowser.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/otel-api-globals.ts
+++ b/packages/web/src/otel-api-globals.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/polyfill-safari10.ts
+++ b/packages/web/src/polyfill-safari10.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/servertiming.ts
+++ b/packages/web/src/servertiming.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/services/BrowserInstanceService.ts
+++ b/packages/web/src/services/BrowserInstanceService.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/session/constants.ts
+++ b/packages/web/src/session/constants.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/session/cookie-session.ts
+++ b/packages/web/src/session/cookie-session.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/session/index.ts
+++ b/packages/web/src/session/index.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/session/local-storage-session.ts
+++ b/packages/web/src/session/local-storage-session.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/session/session.ts
+++ b/packages/web/src/session/session.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/session/types.ts
+++ b/packages/web/src/session/types.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/session/utils.ts
+++ b/packages/web/src/session/utils.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/synthetics.ts
+++ b/packages/web/src/synthetics.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/types/config.ts
+++ b/packages/web/src/types/config.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/upstream/user-interaction/enums/AttributeNames.ts
+++ b/packages/web/src/upstream/user-interaction/enums/AttributeNames.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/upstream/user-interaction/instrumentation.ts
+++ b/packages/web/src/upstream/user-interaction/instrumentation.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/upstream/user-interaction/internal-types.ts
+++ b/packages/web/src/upstream/user-interaction/internal-types.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/upstream/user-interaction/types.ts
+++ b/packages/web/src/upstream/user-interaction/types.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/upstream/user-interaction/version.ts
+++ b/packages/web/src/upstream/user-interaction/version.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/utils/storage.ts
+++ b/packages/web/src/utils/storage.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/utils/throttle.ts
+++ b/packages/web/src/utils/throttle.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/version.ts
+++ b/packages/web/src/version.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/src/webvitals.ts
+++ b/packages/web/src/webvitals.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/SessionBasedSampler.test.ts
+++ b/packages/web/test/SessionBasedSampler.test.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/SplunkContextManager.test.ts
+++ b/packages/web/test/SplunkContextManager.test.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/SplunkExporter.test.ts
+++ b/packages/web/test/SplunkExporter.test.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/SplunkOtelWeb.test.ts
+++ b/packages/web/test/SplunkOtelWeb.test.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/SplunkSpanAttributesProcessor.test.ts
+++ b/packages/web/test/SplunkSpanAttributesProcessor.test.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/api.test.ts
+++ b/packages/web/test/api.test.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/index.ts
+++ b/packages/web/test/index.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/init.test.ts
+++ b/packages/web/test/init.test.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/nodejs.test.ts
+++ b/packages/web/test/nodejs.test.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/plugins/socketio-server.js
+++ b/packages/web/test/plugins/socketio-server.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/servertiming.test.ts
+++ b/packages/web/test/servertiming.test.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/session.test.ts
+++ b/packages/web/test/session.test.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/socketio.test.ts
+++ b/packages/web/test/socketio.test.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/stacktrace.test.ts
+++ b/packages/web/test/stacktrace.test.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/synthetics.test.ts
+++ b/packages/web/test/synthetics.test.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/utils.test.ts
+++ b/packages/web/test/utils.test.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/utils.ts
+++ b/packages/web/test/utils.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/web/test/websockets.test.ts
+++ b/packages/web/test/websockets.test.ts
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rollup.shared.mjs
+++ b/rollup.shared.mjs
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scripts/_utils.mjs
+++ b/scripts/_utils.mjs
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scripts/release-cdn.mjs
+++ b/scripts/release-cdn.mjs
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scripts/tag-check.js
+++ b/scripts/tag-check.js
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scripts/version-check.mjs
+++ b/scripts/version-check.mjs
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scripts/version-update.mjs
+++ b/scripts/version-update.mjs
@@ -1,12 +1,12 @@
 /**
  *
- * Copyright 2024 Splunk Inc.
+ * Copyright 2020-2025 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
# Description

Adds the year 2025 to the header. I included "2020-2025" because 2020 is the year when the license file was first added to the repository.

## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)


# How has this been tested?

N/A

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
