### PR TITLE
fix: add http.response.status_code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"globals": "^15.11.0",
 				"prettier": "^3.3.3",
 				"size-limit": "^11.1.6",
-				"typescript": "^5.1.6",
+				"typescript": "^5.7.3",
 				"typescript-eslint": "^8.12.2"
 			},
 			"engines": {
@@ -18005,10 +18005,11 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+			"integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"globals": "^15.11.0",
 		"prettier": "^3.3.3",
 		"size-limit": "^11.1.6",
-		"typescript": "^5.1.6",
+		"typescript": "^5.7.3",
 		"typescript-eslint": "^8.12.2"
 	}
 }

--- a/packages/integration-tests/src/tests/docload/docload.spec.ts
+++ b/packages/integration-tests/src/tests/docload/docload.spec.ts
@@ -50,7 +50,7 @@ test.describe('docload', () => {
 		}
 	})
 
-	test('documentFetch, resourceFetch, and documentLoad spans', async ({ recordPage }) => {
+	test('documentFetch, resourceFetch, and documentLoad spans', async ({ recordPage, browserName }) => {
 		await recordPage.goTo('/docload/docload.ejs')
 
 		await recordPage.waitForSpans((spans) => spans.filter((span) => span.name === 'documentLoad').length === 1)
@@ -96,6 +96,11 @@ test.describe('docload', () => {
 
 		expect(docFetchSpans[0].tags['link.traceId']).toBeDefined()
 		expect(docFetchSpans[0].tags['link.spanId']).toBeDefined()
+		if (browserName !== 'webkit') {
+			// Webkit does not support https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/responseStatus
+			expect(parseInt(docFetchSpans[0].tags['http.response.status_code'] as string)).toBeGreaterThan(0)
+		}
+
 		expect(parseInt(scriptFetchSpans[0].tags['http.response_content_length'] as string)).toBeGreaterThan(0)
 
 		expect(docLoadSpans[0].tags['component']).toBe('document-load')

--- a/packages/session-recorder/tsconfig.base.json
+++ b/packages/session-recorder/tsconfig.base.json
@@ -8,7 +8,8 @@
 		"pretty": true,
 		"resolveJsonModule": true,
 		"target": "ES2017",
-		"types": ["node"]
+		"types": ["node"],
+		"skipLibCheck": true
 	},
 	"include": ["src/**/*.ts", "src/**/*.js"],
 	"exclude": ["node_modules"]

--- a/packages/web/src/SplunkDocumentLoadInstrumentation.ts
+++ b/packages/web/src/SplunkDocumentLoadInstrumentation.ts
@@ -76,8 +76,8 @@ export class SplunkDocumentLoadInstrumentation extends DocumentLoadInstrumentati
 						;(entries as PerformanceEntriesWithServerTiming).serverTiming = navEntries[0].serverTiming
 					}
 
-					if (navEntries[0]?.responseStatus) {
-						span.setAttribute('http.response.status_code', navEntries[0].responseStatus)
+					if ((navEntries[0] as any)?.responseStatus) {
+						span.setAttribute('http.response.status_code', (navEntries[0] as any).responseStatus)
 					}
 				}
 

--- a/packages/web/src/SplunkDocumentLoadInstrumentation.ts
+++ b/packages/web/src/SplunkDocumentLoadInstrumentation.ts
@@ -76,8 +76,8 @@ export class SplunkDocumentLoadInstrumentation extends DocumentLoadInstrumentati
 						;(entries as PerformanceEntriesWithServerTiming).serverTiming = navEntries[0].serverTiming
 					}
 
-					if ((navEntries[0] as any)?.responseStatus) {
-						span.setAttribute('http.response.status_code', (navEntries[0] as any).responseStatus)
+					if (navEntries[0]?.responseStatus) {
+						span.setAttribute('http.response.status_code', navEntries[0].responseStatus)
 					}
 				}
 

--- a/packages/web/tsconfig.base.json
+++ b/packages/web/tsconfig.base.json
@@ -8,7 +8,8 @@
 		"pretty": true,
 		"resolveJsonModule": true,
 		"target": "ES2017",
-		"types": ["node"]
+		"types": ["node"],
+		"skipLibCheck": true
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["node_modules"]


### PR DESCRIPTION
# Description

Add 'http.response.status_code' to documentFetch span.

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added integration tests
