### PR TITLE
chore: explicitly set packages for release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ build_artifacts:
     script:
         - if [ ! -d "artifacts" ]; then mkdir artifacts; fi
         - npm run compile
-        - npm pack --pack-destination artifacts -ws
+        - npm pack --pack-destination artifacts --workspace packages/session-recorder --workspace packages/web
 
         # complete artifacts & checksums
         - cp packages/*/dist/artifacts/* artifacts/


### PR DESCRIPTION
# Description

Set packages for release explicitly to prevent incidental release of private packages

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Delete options that are not relevant.

- Manual testing

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
