### PR TITLE
chore: use old tag name for compatibility - http.status_code

### DIFF
--- a/packages/integration-tests/src/tests/docload/docload.spec.ts
+++ b/packages/integration-tests/src/tests/docload/docload.spec.ts
@@ -98,7 +98,7 @@ test.describe('docload', () => {
 		expect(docFetchSpans[0].tags['link.spanId']).toBeDefined()
 		if (browserName !== 'webkit') {
 			// Webkit does not support https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/responseStatus
-			expect(parseInt(docFetchSpans[0].tags['http.response.status_code'] as string)).toBe(200)
+			expect(parseInt(docFetchSpans[0].tags['http.status_code'] as string)).toBe(200)
 		}
 
 		expect(parseInt(scriptFetchSpans[0].tags['http.response_content_length'] as string)).toBeGreaterThan(0)

--- a/packages/web/src/SplunkDocumentLoadInstrumentation.ts
+++ b/packages/web/src/SplunkDocumentLoadInstrumentation.ts
@@ -77,7 +77,7 @@ export class SplunkDocumentLoadInstrumentation extends DocumentLoadInstrumentati
 					}
 
 					if (navEntries[0]?.responseStatus) {
-						span.setAttribute('http.response.status_code', navEntries[0].responseStatus)
+						span.setAttribute('http.status_code', navEntries[0].responseStatus)
 					}
 				}
 


### PR DESCRIPTION
New tag name will be used later

# Description

Use `http.status_code` instead of new otel name due to compatibility reasons.

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Integration testing
