### PR TITLE
feat: bots & automation frameworks detection

### DIFF
--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -24,13 +24,13 @@ module.exports = [
 
 	{
 		name: 'artifacts/splunk-otel-web.js',
-		limit: '41 kB',
+		limit: '42 kB',
 		path: './packages/web/dist/artifacts/splunk-otel-web.js',
 	},
 
 	{
 		name: 'artifacts/splunk-otel-web.js',
-		limit: '73 kB',
+		limit: '74 kB',
 		path: './packages/web/dist/artifacts/splunk-otel-web-legacy.js',
 	},
 

--- a/packages/integration-tests/src/tests/automation-frameworks/automation-frameworks-disabled.ejs
+++ b/packages/integration-tests/src/tests/automation-frameworks/automation-frameworks-disabled.ejs
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Automation frameworks disabled test</title>
+
+	<%- renderAgent({ debug: true, disableAutomationFrameworks: true }) %>
+</head>
+<body>
+  <h1>Automation frameworks disabled test</h1>
+  <pre id="scenarioDisplay"></pre>
+  <script>scenarioDisplay.innerHTML = scenario.innerHTML;</script>
+</body>
+</html>

--- a/packages/integration-tests/src/tests/automation-frameworks/automation-frameworks-enabled.ejs
+++ b/packages/integration-tests/src/tests/automation-frameworks/automation-frameworks-enabled.ejs
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Automation frameworks allowed test</title>
+
+	<%- renderAgent({ debug: true }) %>
+
+	<script>console.log(navigator.userAgent)</script>
+</head>
+<body>
+  <h1>Automation frameworks allowed test</h1>
+  <pre id="scenarioDisplay"></pre>
+  <script>scenarioDisplay.innerHTML = scenario.innerHTML;</script>
+</body>
+</html>

--- a/packages/integration-tests/src/tests/automation-frameworks/automation-frameworks.spec.ts
+++ b/packages/integration-tests/src/tests/automation-frameworks/automation-frameworks.spec.ts
@@ -21,7 +21,7 @@ import { test } from '../../utils/test'
 test.describe('Automation frameworks', () => {
 	test('Tracking is working for playwright with automation frameworks enabled', async ({ recordPage }) => {
 		await recordPage.goTo('/automation-frameworks/automation-frameworks-enabled.ejs')
-		await recordPage.waitForTimeout(1000)
+		await recordPage.waitForSpans(() => true)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})

--- a/packages/integration-tests/src/tests/automation-frameworks/automation-frameworks.spec.ts
+++ b/packages/integration-tests/src/tests/automation-frameworks/automation-frameworks.spec.ts
@@ -1,0 +1,35 @@
+/**
+ *
+ * Copyright 2020-2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { expect } from '@playwright/test'
+import { test } from '../../utils/test'
+
+test.describe('Automation frameworks', () => {
+	test('Tracking is working for playwright with automation frameworks enabled', async ({ recordPage }) => {
+		await recordPage.goTo('/automation-frameworks/automation-frameworks-enabled.ejs')
+		await recordPage.waitForTimeout(1000)
+
+		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
+	})
+
+	test('Tracking is not working for playwright with automation frameworks disabled', async ({ recordPage }) => {
+		await recordPage.goTo('/automation-frameworks/automation-frameworks-disabled.ejs')
+		await recordPage.waitForTimeout(1000)
+
+		expect(recordPage.receivedSpans).toHaveLength(0)
+	})
+})

--- a/packages/integration-tests/src/tests/automation-frameworks/automation-frameworks.spec.ts
+++ b/packages/integration-tests/src/tests/automation-frameworks/automation-frameworks.spec.ts
@@ -21,7 +21,7 @@ import { test } from '../../utils/test'
 test.describe('Automation frameworks', () => {
 	test('Tracking is working for playwright with automation frameworks enabled', async ({ recordPage }) => {
 		await recordPage.goTo('/automation-frameworks/automation-frameworks-enabled.ejs')
-		await recordPage.waitForSpans(() => true)
+		await recordPage.waitForSpans((spans) => spans.length > 0)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})

--- a/packages/integration-tests/src/tests/bots/bots-disabled.ejs
+++ b/packages/integration-tests/src/tests/bots/bots-disabled.ejs
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Bots disabled test</title>
+
+	<%- renderAgent({ debug: true }) %>
+</head>
+<body>
+  <h1>Bots disabled test</h1>
+  <pre id="scenarioDisplay"></pre>
+  <script>scenarioDisplay.innerHTML = scenario.innerHTML;</script>
+</body>
+</html>

--- a/packages/integration-tests/src/tests/bots/bots-enabled.ejs
+++ b/packages/integration-tests/src/tests/bots/bots-enabled.ejs
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Bots allowed test</title>
+
+	<%- renderAgent({ debug: true, allowBots: true }) %>
+
+	<script>console.log(navigator.userAgent)</script>
+</head>
+<body>
+  <h1>Bots allowed test</h1>
+  <pre id="scenarioDisplay"></pre>
+  <script>scenarioDisplay.innerHTML = scenario.innerHTML;</script>
+</body>
+</html>

--- a/packages/integration-tests/src/tests/bots/bots.spec.ts
+++ b/packages/integration-tests/src/tests/bots/bots.spec.ts
@@ -1,0 +1,123 @@
+/**
+ *
+ * Copyright 2020-2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { expect } from '@playwright/test'
+import { test } from '../../utils/test'
+
+test.describe('Bots - Google bot', () => {
+	test.use({
+		userAgent:
+			'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.92 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+	})
+
+	test('Tracking is working for google bot with bots enabled', async ({ recordPage }) => {
+		await recordPage.goTo('/bots/bots-enabled.ejs')
+		await recordPage.waitForTimeout(1000)
+
+		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
+	})
+
+	test('Tracking is not working for google bot with bots disabled', async ({ recordPage }) => {
+		await recordPage.goTo('/bots/bots-disabled.ejs')
+		await recordPage.waitForTimeout(1000)
+
+		expect(recordPage.receivedSpans).toHaveLength(0)
+	})
+})
+
+test.describe('Bots - Splunk synthetics', () => {
+	test.use({
+		userAgent:
+			'Mozilla/5.0 (Linux; Android 8.0.0; SM-G965U Build/R16NW; Splunk Synthetics) AppleWebKit/537.36 (KHTML, like Gecko)Chrome/127.0.6533.88 Mobile Safari/537.36',
+	})
+
+	test('Tracking is working for Splunk Synthetics with bots enabled', async ({ recordPage }) => {
+		await recordPage.goTo('/bots/bots-enabled.ejs')
+		await recordPage.waitForTimeout(1000)
+
+		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
+	})
+
+	test('Tracking is working for Splunk Synthetics with bots disabled', async ({ recordPage }) => {
+		await recordPage.goTo('/bots/bots-disabled.ejs')
+		await recordPage.waitForTimeout(1000)
+
+		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
+	})
+})
+
+test.describe('Bots - Real browser - Chrome', () => {
+	test.use({
+		userAgent:
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36',
+	})
+
+	test('Tracking is working for real browser Chrome with bots enabled', async ({ recordPage }) => {
+		await recordPage.goTo('/bots/bots-enabled.ejs')
+		await recordPage.waitForTimeout(1000)
+
+		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
+	})
+
+	test('Tracking is working for real browser Chrome with bots disabled', async ({ recordPage }) => {
+		await recordPage.goTo('/bots/bots-disabled.ejs')
+		await recordPage.waitForTimeout(1000)
+
+		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
+	})
+})
+
+test.describe('Bots - Real browser - Safari', () => {
+	test.use({
+		userAgent:
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Safari/605.1.15',
+	})
+
+	test('Tracking is working for real browser Safari with bots enabled', async ({ recordPage }) => {
+		await recordPage.goTo('/bots/bots-enabled.ejs')
+		await recordPage.waitForTimeout(1000)
+
+		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
+	})
+
+	test('Tracking is working for real browser Safari with bots disabled', async ({ recordPage }) => {
+		await recordPage.goTo('/bots/bots-disabled.ejs')
+		await recordPage.waitForTimeout(1000)
+
+		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
+	})
+})
+
+test.describe('Bots - Real browser - Firefox', () => {
+	test.use({
+		userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:134.0) Gecko/20100101 Firefox/134.0',
+	})
+
+	test('Tracking is working for real browser Firefox with bots enabled', async ({ recordPage }) => {
+		await recordPage.goTo('/bots/bots-enabled.ejs')
+		await recordPage.waitForTimeout(1000)
+
+		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
+	})
+
+	test('Tracking is working for real browser Firefox with bots disabled', async ({ recordPage }) => {
+		await recordPage.goTo('/bots/bots-disabled.ejs')
+		await recordPage.waitForTimeout(1000)
+
+		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
+	})
+})

--- a/packages/integration-tests/src/tests/bots/bots.spec.ts
+++ b/packages/integration-tests/src/tests/bots/bots.spec.ts
@@ -26,7 +26,7 @@ test.describe('Bots - Google bot', () => {
 
 	test('Tracking is working for google bot with bots enabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-enabled.ejs')
-		await recordPage.waitForTimeout(1000)
+		await recordPage.waitForSpans(() => true)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})
@@ -47,7 +47,7 @@ test.describe('Bots - Splunk synthetics', () => {
 
 	test('Tracking is working for Splunk Synthetics with bots enabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-enabled.ejs')
-		await recordPage.waitForTimeout(1000)
+		await recordPage.waitForSpans(() => true)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})
@@ -68,14 +68,14 @@ test.describe('Bots - Real browser - Chrome', () => {
 
 	test('Tracking is working for real browser Chrome with bots enabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-enabled.ejs')
-		await recordPage.waitForTimeout(1000)
+		await recordPage.waitForSpans(() => true)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})
 
 	test('Tracking is working for real browser Chrome with bots disabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-disabled.ejs')
-		await recordPage.waitForTimeout(1000)
+		await recordPage.waitForSpans(() => true)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})
@@ -89,14 +89,14 @@ test.describe('Bots - Real browser - Safari', () => {
 
 	test('Tracking is working for real browser Safari with bots enabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-enabled.ejs')
-		await recordPage.waitForTimeout(1000)
+		await recordPage.waitForSpans(() => true)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})
 
 	test('Tracking is working for real browser Safari with bots disabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-disabled.ejs')
-		await recordPage.waitForTimeout(1000)
+		await recordPage.waitForSpans(() => true)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})
@@ -109,14 +109,14 @@ test.describe('Bots - Real browser - Firefox', () => {
 
 	test('Tracking is working for real browser Firefox with bots enabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-enabled.ejs')
-		await recordPage.waitForTimeout(1000)
+		await recordPage.waitForSpans(() => true)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})
 
 	test('Tracking is working for real browser Firefox with bots disabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-disabled.ejs')
-		await recordPage.waitForTimeout(1000)
+		await recordPage.waitForSpans(() => true)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})

--- a/packages/integration-tests/src/tests/bots/bots.spec.ts
+++ b/packages/integration-tests/src/tests/bots/bots.spec.ts
@@ -54,7 +54,7 @@ test.describe('Bots - Splunk synthetics', () => {
 
 	test('Tracking is working for Splunk Synthetics with bots disabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-disabled.ejs')
-		await recordPage.waitForTimeout(1000)
+		await recordPage.waitForSpans(() => true)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})

--- a/packages/integration-tests/src/tests/bots/bots.spec.ts
+++ b/packages/integration-tests/src/tests/bots/bots.spec.ts
@@ -26,7 +26,7 @@ test.describe('Bots - Google bot', () => {
 
 	test('Tracking is working for google bot with bots enabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-enabled.ejs')
-		await recordPage.waitForSpans(() => true)
+		await recordPage.waitForSpans((spans) => spans.length > 0)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})
@@ -47,14 +47,14 @@ test.describe('Bots - Splunk synthetics', () => {
 
 	test('Tracking is working for Splunk Synthetics with bots enabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-enabled.ejs')
-		await recordPage.waitForSpans(() => true)
+		await recordPage.waitForSpans((spans) => spans.length > 0)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})
 
 	test('Tracking is working for Splunk Synthetics with bots disabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-disabled.ejs')
-		await recordPage.waitForSpans(() => true)
+		await recordPage.waitForSpans((spans) => spans.length > 0)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})
@@ -68,14 +68,14 @@ test.describe('Bots - Real browser - Chrome', () => {
 
 	test('Tracking is working for real browser Chrome with bots enabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-enabled.ejs')
-		await recordPage.waitForSpans(() => true)
+		await recordPage.waitForSpans((spans) => spans.length > 0)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})
 
 	test('Tracking is working for real browser Chrome with bots disabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-disabled.ejs')
-		await recordPage.waitForSpans(() => true)
+		await recordPage.waitForSpans((spans) => spans.length > 0)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})
@@ -89,14 +89,14 @@ test.describe('Bots - Real browser - Safari', () => {
 
 	test('Tracking is working for real browser Safari with bots enabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-enabled.ejs')
-		await recordPage.waitForSpans(() => true)
+		await recordPage.waitForSpans((spans) => spans.length > 0)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})
 
 	test('Tracking is working for real browser Safari with bots disabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-disabled.ejs')
-		await recordPage.waitForSpans(() => true)
+		await recordPage.waitForSpans((spans) => spans.length > 0)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})
@@ -109,14 +109,14 @@ test.describe('Bots - Real browser - Firefox', () => {
 
 	test('Tracking is working for real browser Firefox with bots enabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-enabled.ejs')
-		await recordPage.waitForSpans(() => true)
+		await recordPage.waitForSpans((spans) => spans.length > 0)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})
 
 	test('Tracking is working for real browser Firefox with bots disabled', async ({ recordPage }) => {
 		await recordPage.goTo('/bots/bots-disabled.ejs')
-		await recordPage.waitForSpans(() => true)
+		await recordPage.waitForSpans((spans) => spans.length > 0)
 
 		expect(recordPage.receivedSpans.length).toBeGreaterThan(0)
 	})

--- a/packages/integration-tests/tsconfig.json
+++ b/packages/integration-tests/tsconfig.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
 		"target": "esnext",
-		"moduleResolution": "nodenext"
+		"moduleResolution": "nodenext",
+		"module": "NodeNext"
 	}
 }

--- a/packages/session-recorder/src/index.ts
+++ b/packages/session-recorder/src/index.ts
@@ -113,7 +113,17 @@ const SplunkRumRecorder = {
 		}
 
 		if (typeof window === 'undefined') {
-			console.error("Session recorder can't be ran in non-browser environments")
+			console.error("Session recorder can't be run in non-browser environments.")
+			return
+		}
+
+		if ('SplunkRum' in window && (window.SplunkRum as SplunkOtelWebType).disabledByBotDetection) {
+			console.warn('The session recorder will not be initialized because bots are not allowed.')
+			return
+		}
+
+		if ('SplunkRum' in window && (window.SplunkRum as SplunkOtelWebType).disabledByAutomationFrameworkDetection) {
+			console.warn('The session recorder will not be initialized because automation frameworks are not allowed.')
 			return
 		}
 

--- a/packages/session-recorder/src/utils.ts
+++ b/packages/session-recorder/src/utils.ts
@@ -16,23 +16,22 @@
  *
  */
 
-import { VERSION } from './version'
-
 const GLOBAL_OPENTELEMETRY_API_KEY = Symbol.for('opentelemetry.js.api.1')
+
+const GLOBAL_SPLUNK_RUM_KEY = 'splunk.rum'
+
+const GLOBAL_SPLUNK_RUM_VERSION_KEY = `${GLOBAL_SPLUNK_RUM_KEY}.version`
+
 /**
  * otel-api's global function. This isn't exported by otel/api but would be
  * super useful to access global components for experimental purposes...
  * For us, it's included to access components accessed by other packages,
  * eg. sharing session id manager with session recorder
  */
-export function getGlobal<Type>(type: string): Type | undefined {
-	const globalSplunkRumVersion = globalThis[GLOBAL_OPENTELEMETRY_API_KEY]?.['splunk.rum.version']
-	if (!globalSplunkRumVersion || globalSplunkRumVersion !== VERSION) {
-		console.warn(
-			`SplunkSessionRecorder: Version mismatch with SplunkRum (RUM: ${globalSplunkRumVersion}, recorder: ${VERSION})`,
-		)
-		return undefined // undefined for eslint
-	}
+export function getGlobal<Type>(): Type | undefined {
+	return globalThis[GLOBAL_OPENTELEMETRY_API_KEY]?.[GLOBAL_SPLUNK_RUM_KEY]
+}
 
-	return globalThis[GLOBAL_OPENTELEMETRY_API_KEY]?.[type]
+export function getSplunkRumVersion(): string | undefined {
+	return globalThis[GLOBAL_OPENTELEMETRY_API_KEY]?.[GLOBAL_SPLUNK_RUM_VERSION_KEY]
 }

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -271,26 +271,13 @@ export const SplunkRum: SplunkOtelWebType = {
 	},
 
 	init: function (options) {
-		if (!options.allowBots && isBot(navigator.userAgent)) {
-			console.warn('SplunkRum will not be initialized because bots are not allowed.')
-
-			this.disabledByBotDetection = true
-			return
-		}
-
-		if (options.disableAutomationFrameworks && navigator.webdriver) {
-			console.warn('SplunkRum will not be initialized because automation frameworks are not allowed.')
-			this.disableAutomationFrameworks = true
-			return
-		}
-
 		// "env" based config still a bad idea for web
 		if (!('OTEL_TRACES_EXPORTER' in _globalThis)) {
 			_globalThis.OTEL_TRACES_EXPORTER = 'none'
 		}
 
 		if (inited) {
-			console.warn('SplunkRum already init()ed.')
+			console.warn('SplunkRum already initialized.')
 			return
 		}
 
@@ -309,6 +296,18 @@ export const SplunkRum: SplunkOtelWebType = {
 
 		if (typeof Symbol !== 'function') {
 			diag.error('SplunkRum: browser not supported, disabling instrumentation.')
+			return
+		}
+
+		if (!options.allowBots && isBot(navigator.userAgent)) {
+			this.disabledByBotDetection = true
+			diag.error('SplunkRum will not be initialized, bots are not allowed.')
+			return
+		}
+
+		if (options.disableAutomationFrameworks && navigator.webdriver) {
+			this.disableAutomationFrameworks = true
+			diag.error('SplunkRum will not be initialized, automation frameworks are not allowed.')
 			return
 		}
 

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -208,6 +208,16 @@ export interface SplunkOtelWebType extends SplunkOtelWebEventTarget {
 
 	deinit: (force?: boolean) => void
 
+	/**
+	 * True if library detected an automation framework and was disabled based on 'disableAutomationFrameworks' setting.
+	 */
+	disabledByAutomationFrameworkDetection?: boolean
+
+	/**
+	 * True if library detected a bot and was disabled based on 'allowBots' setting.
+	 */
+	disabledByBotDetection?: boolean
+
 	error: (...args: Array<any>) => void
 
 	/**
@@ -262,12 +272,15 @@ export const SplunkRum: SplunkOtelWebType = {
 
 	init: function (options) {
 		if (!options.allowBots && isBot(navigator.userAgent)) {
-			console.warn('SplunkRum wont be initialized. Bots are not allowed.')
+			console.warn('SplunkRum will not be initialized because bots are not allowed.')
+
+			this.disabledByBotDetection = true
 			return
 		}
 
 		if (options.disableAutomationFrameworks && navigator.webdriver) {
-			console.warn('SplunkRum wont be initialized. Automation frameworks are not allowed.')
+			console.warn('SplunkRum will not be initialized because automation frameworks are not allowed.')
+			this.disableAutomationFrameworks = true
 			return
 		}
 

--- a/packages/web/src/types/config.ts
+++ b/packages/web/src/types/config.ts
@@ -72,6 +72,11 @@ export interface SplunkOtelWebConfig {
 	 */
 	_experimental_longtaskNoStartSession?: boolean
 
+	/*
+	 * If enabled, bots like google bot, bing bot, and others will be tracked. Defaults to false.
+	 */
+	allowBots?: boolean
+
 	/** Allows http beacon urls */
 	allowInsecureBeacon?: boolean
 
@@ -105,6 +110,11 @@ export interface SplunkOtelWebConfig {
 	 * Sets a value for the `environment` attribute (persists through calls to `setGlobalAttributes()`)
 	 * */
 	deploymentEnvironment?: string
+
+	/*
+	 * If true, automation frameworks like Cypress, Selenium, Playwright, Synthetics will not be tracked. Defaults to false.
+	 */
+	disableAutomationFrameworks?: boolean
 
 	/**
 	 * Sets a value for the `environment` attribute (persists through calls to `setGlobalAttributes()`)

--- a/packages/web/src/utils/is-bot.ts
+++ b/packages/web/src/utils/is-bot.ts
@@ -1,0 +1,30 @@
+/**
+ *
+ * Copyright 2020-2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// https://github.com/omrilotan/isbot
+
+// Removed synthetic from regex, pattern from v5.1.22
+
+const pattern = new RegExp(
+	' daum[ /]| deusu/| yadirectfetcher|(?:^|[^g])news(?!sapphire)|(?<! (?:channel/|google/))google(?!(app|/google| pixel))|(?<! cu)bots?(?:\\b|_)|(?<!(?:lib))http|(?<![hg]m)score|@[a-z][\\w-]+\\.|\\(\\)|\\.com\\b|\\btime/|^<|^[\\w \\.\\-\\(?:\\):%]+(?:/v?\\d+(?:\\.\\d+)?(?:\\.\\d{1,10})*?)?(?:,|$)|^[^ ]{50,}$|^\\d+\\b|^\\w*search\\b|^\\w+/[\\w\\(\\)]*$|^active|^ad muncher|^amaya|^avsdevicesdk/|^biglotron|^bot|^bw/|^clamav[ /]|^client/|^cobweb/|^custom|^ddg[_-]android|^discourse|^dispatch/\\d|^downcast/|^duckduckgo|^email|^facebook|^getright/|^gozilla/|^hobbit|^hotzonu|^hwcdn/|^igetter/|^jeode/|^jetty/|^jigsaw|^microsoft bits|^movabletype|^mozilla/5\\.0\\s[a-z\\.-]+$|^mozilla/\\d\\.\\d \\(compatible;?\\)$|^mozilla/\\d\\.\\d \\w*$|^navermailapp|^netsurf|^offline|^openai/|^owler|^php|^postman|^python|^rank|^read|^reed|^rest|^rss|^snapchat|^space bison|^svn|^swcd |^taringa|^thumbor/|^track|^w3c|^webbandit/|^webcopier|^wget|^whatsapp|^wordpress|^xenu link sleuth|^yahoo|^yandex|^zdm/\\d|^zoom marketplace/|^{{.*}}$|adscanner/|analyzer|archive|ask jeeves/teoma|audit|bit\\.ly/|bluecoat drtr|browsex|burpcollaborator|capture|catch|check\\b|checker|chrome-lighthouse|chromeframe|classifier|cloudflare|convertify|cookiehubscan|crawl|cypress/|dareboost|datanyze|dejaclick|detect|dmbrowser|download|evc-batch/|exaleadcloudview|feed|firephp|functionize|gomezagent|headless|httrack|hubspot marketing grader|hydra|ibisbrowser|images|infrawatch|insight|inspect|iplabel|ips-agent|java(?!;)|jsjcw_scanner|library|linkcheck|mail\\.ru/|manager|measure|neustar wpm|node|nutch|offbyone|optimize|pageburst|pagespeed|parser|perl|phantomjs|pingdom|powermarks|preview|proxy|ptst[ /]\\d|reputation|resolver|retriever|rexx;|rigor|rss\\b|scanner\\.|scrape|server|sogou|sparkler/|speedcurve|spider|splash|statuscake|supercleaner|synapse|tools|torrent|trace|transcoder|url|validator|virtuoso|wappalyzer|webglance|webkit2png|whatcms/|zgrab',
+	'i',
+)
+
+export function isBot(userAgent?: string | null): boolean {
+	return Boolean(userAgent) && pattern.test(userAgent)
+}

--- a/packages/web/test/SplunkContextManager.test.ts
+++ b/packages/web/test/SplunkContextManager.test.ts
@@ -26,6 +26,7 @@ describe('async context propagation', () => {
 	const capturer = new SpanCapturer()
 	beforeEach(() => {
 		SplunkOtelWeb.init({
+			allowBots: true,
 			applicationName: 'my-app',
 			beaconEndpoint: 'https://localhost:9411/api/traces',
 			rumAccessToken: 'xxx',

--- a/packages/web/test/SplunkOtelWeb.test.ts
+++ b/packages/web/test/SplunkOtelWeb.test.ts
@@ -29,6 +29,7 @@ describe('SplunkOtelWeb', () => {
 	describe('global attributes', () => {
 		it('should be settable via constructor and then readable', () => {
 			SplunkRum.init({
+				allowBots: true,
 				applicationName: 'app-name',
 				beaconEndpoint: 'https://beacon',
 				rumAccessToken: '<token>',
@@ -43,6 +44,7 @@ describe('SplunkOtelWeb', () => {
 
 		it('should be patchable via setGlobalAttributes and then readable', () => {
 			SplunkRum.init({
+				allowBots: true,
 				applicationName: 'app-name',
 				beaconEndpoint: 'https://beacon',
 				rumAccessToken: '<token>',
@@ -66,6 +68,7 @@ describe('SplunkOtelWeb', () => {
 
 		it('should notify about changes via setGlobalAttributes', async () => {
 			SplunkRum.init({
+				allowBots: true,
 				applicationName: 'app-name',
 				beaconEndpoint: 'https://beacon',
 				rumAccessToken: '<token>',
@@ -101,6 +104,7 @@ describe('SplunkOtelWeb', () => {
 			expect(SplunkRum.getSessionId()).to.eq(undefined)
 
 			SplunkRum.init({
+				allowBots: true,
 				applicationName: 'app-name',
 				beaconEndpoint: 'https://beacon',
 				rumAccessToken: '<token>',
@@ -115,6 +119,7 @@ describe('SplunkOtelWeb', () => {
 			let sessionId: string | undefined
 
 			SplunkRum.init({
+				allowBots: true,
 				applicationName: 'app-name',
 				beaconEndpoint: 'https://beacon',
 				rumAccessToken: '<token>',
@@ -138,6 +143,7 @@ describe('SplunkOtelWeb', () => {
 			expect(SplunkRum.inited).to.eq(false, 'Should be false in the beginning.')
 
 			SplunkRum.init({
+				allowBots: true,
 				applicationName: 'app-name',
 				beaconEndpoint: 'https://beacon',
 				rumAccessToken: '<token>',

--- a/packages/web/test/api.test.ts
+++ b/packages/web/test/api.test.ts
@@ -29,6 +29,7 @@ describe('Transitive API', () => {
 
 	beforeEach(() => {
 		SplunkOtelWeb.init({
+			allowBots: true,
 			applicationName: 'my-app',
 			beaconEndpoint: 'https://localhost:9411/api/traces',
 			rumAccessToken: 'xxx',

--- a/packages/web/test/init.test.ts
+++ b/packages/web/test/init.test.ts
@@ -52,7 +52,12 @@ describe('test init', () => {
 	describe('not specifying beaconUrl', () => {
 		it('should not be inited', () => {
 			try {
-				SplunkRum.init({ beaconEndpoint: undefined, applicationName: 'app', rumAccessToken: undefined })
+				SplunkRum.init({
+					allowBots: true,
+					beaconEndpoint: undefined,
+					applicationName: 'app',
+					rumAccessToken: undefined,
+				})
 				assert.ok(false, 'Initializer finished.') // should not get here
 			} catch {
 				assert.ok(SplunkRum.inited === false, 'SplunkRum should not be inited.')
@@ -63,6 +68,7 @@ describe('test init', () => {
 		it('should not be inited with http', () => {
 			try {
 				SplunkRum.init({
+					allowBots: true,
 					beaconEndpoint: 'http://127.0.0.1:8888/insecure',
 					applicationName: 'app',
 					rumAccessToken: undefined,
@@ -75,6 +81,7 @@ describe('test init', () => {
 		it('should init with https', () => {
 			const path = '/secure'
 			SplunkRum.init({
+				allowBots: true,
 				beaconEndpoint: `https://127.0.0.1:8888/${path}`,
 				applicationName: 'app',
 				rumAccessToken: undefined,
@@ -85,6 +92,7 @@ describe('test init', () => {
 		it('can be forced via allowInsecureBeacon option', () => {
 			const path = '/insecure'
 			SplunkRum.init({
+				allowBots: true,
 				beaconEndpoint: `http://127.0.0.1:8888/${path}`,
 				allowInsecureBeacon: true,
 				applicationName: 'app',
@@ -94,16 +102,13 @@ describe('test init', () => {
 			doesBeaconUrlEndWith(path)
 		})
 		it('can use realm config option', () => {
-			SplunkRum.init({
-				realm: 'test',
-				applicationName: 'app',
-				rumAccessToken: undefined,
-			})
+			SplunkRum.init({ allowBots: true, realm: 'test', applicationName: 'app', rumAccessToken: undefined })
 			assert.ok(SplunkRum.inited)
 			doesBeaconUrlEndWith('https://rum-ingest.test.signalfx.com/v1/rum')
 		})
 		it('can use realm + otlp config option', () => {
 			SplunkRum.init({
+				allowBots: true,
 				realm: 'test',
 				applicationName: 'app',
 				rumAccessToken: undefined,
@@ -119,6 +124,7 @@ describe('test init', () => {
 	describe('successful', () => {
 		it('should have been inited properly with doc load spans', (done) => {
 			SplunkRum.init({
+				allowBots: true,
 				beaconEndpoint: 'https://127.0.0.1:9999/foo',
 				applicationName: 'my-app',
 				deploymentEnvironment: 'my-env',
@@ -160,6 +166,7 @@ describe('test init', () => {
 		})
 		it('is backwards compatible with 0.15.3 and earlier config options', () => {
 			SplunkRum.init({
+				allowBots: true,
 				beaconUrl: 'https://127.0.0.1:9999/foo',
 				app: 'my-app',
 				environment: 'my-env',
@@ -173,11 +180,13 @@ describe('test init', () => {
 	describe('double-init has no effect', () => {
 		it('should have been inited only once', () => {
 			SplunkRum.init({
+				allowBots: true,
 				beaconEndpoint: 'https://127.0.0.1:8888/foo',
 				applicationName: 'app',
 				rumAccessToken: undefined,
 			})
 			SplunkRum.init({
+				allowBots: true,
 				beaconEndpoint: 'https://127.0.0.1:8888/bar',
 				applicationName: 'app',
 				rumAccessToken: undefined,
@@ -190,6 +199,7 @@ describe('test init', () => {
 			const exportMock = sinon.fake()
 			const onAttributesSerializingMock = sinon.fake()
 			SplunkRum._internalInit({
+				allowBots: true,
 				beaconEndpoint: 'https://domain1',
 				allowInsecureBeacon: true,
 				applicationName: 'my-app',
@@ -219,6 +229,7 @@ describe('test init', () => {
 	describe('multiple instance protection', () => {
 		function init() {
 			SplunkRum.init({
+				allowBots: true,
 				beaconEndpoint: 'https://127.0.0.1:9999/foo',
 				applicationName: 'my-app',
 				deploymentEnvironment: 'my-env',

--- a/packages/web/test/nodejs.test.ts
+++ b/packages/web/test/nodejs.test.ts
@@ -22,6 +22,7 @@ import SplunkRum from '../src/index'
 describe('Node.js basic support', () => {
 	it('Can call init', () => {
 		SplunkRum.init({
+			allowBots: true,
 			applicationName: 'test-app',
 			beaconEndpoint: 'https://localhost/events',
 			rumAccessToken: 'example1234',

--- a/packages/web/test/utils.ts
+++ b/packages/web/test/utils.ts
@@ -67,6 +67,7 @@ export function buildInMemorySplunkExporter(): {
 
 export function initWithDefaultConfig(capturer: SpanCapturer, additionalOptions = {}): void {
 	SplunkRum._internalInit({
+		allowBots: true,
 		beaconEndpoint: 'http://127.0.0.1:8888/v1/trace',
 		allowInsecureBeacon: true,
 		applicationName: 'my-app',
@@ -89,6 +90,7 @@ export function initWithSyncPipeline(additionalOptions = {}): {
 	const processor = new SimpleSpanProcessor(exporter)
 
 	SplunkRum._internalInit({
+		allowBots: true,
 		beaconEndpoint: 'http://127.0.0.1:8888/v1/trace',
 		allowInsecureBeacon: true,
 		applicationName: 'my-app',


### PR DESCRIPTION
# Description

Disable bots by default using the https://www.npmjs.com/package/isbot package regex
Add option to disable/enable tracking of bots - disabled by default.
Add option to disable/enable tracking of automation frameworks - enabled by default.

## Type of change

- New feature (non-breaking change which adds functionality)

# How has this been tested?

- Manual testing
- Added integration tests