### PR TITLE
chore(build-plugins): add test coverage for source map id injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "@splunk/otel-web-dev-root",
 			"version": "0.20.0-beta.4",
 			"workspaces": [
+				"packages/build-plugins",
 				"packages/web",
 				"packages/session-recorder",
 				"packages/integration-tests"
@@ -3432,7 +3433,6 @@
 		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.5",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/set-array": "^1.2.1",
@@ -3445,7 +3445,6 @@
 		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -3453,7 +3452,6 @@
 		},
 		"node_modules/@jridgewell/set-array": {
 			"version": "1.2.1",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -3461,7 +3459,6 @@
 		},
 		"node_modules/@jridgewell/source-map": {
 			"version": "0.3.6",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
@@ -3470,12 +3467,10 @@
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.15",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.25",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
@@ -5268,6 +5263,10 @@
 			"version": "3.1.2",
 			"license": "MIT"
 		},
+		"node_modules/@splunk/olly-web-build-plugins": {
+			"resolved": "packages/build-plugins",
+			"link": true
+		},
 		"node_modules/@splunk/otel-js-web-integration-tests": {
 			"resolved": "packages/integration-tests",
 			"link": true
@@ -5445,9 +5444,28 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/eslint": {
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+			"integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "*",
+				"@types/json-schema": "*"
+			}
+		},
+		"node_modules/@types/eslint-scope": {
+			"version": "3.7.7",
+			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+			"peer": true,
+			"dependencies": {
+				"@types/eslint": "*",
+				"@types/estree": "*"
+			}
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.5",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/express": {
@@ -5479,7 +5497,6 @@
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/linkify-it": {
@@ -6014,9 +6031,167 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
+		"node_modules/@webassemblyjs/ast": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+			"integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+			"peer": true,
+			"dependencies": {
+				"@webassemblyjs/helper-numbers": "1.13.2",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+			}
+		},
+		"node_modules/@webassemblyjs/floating-point-hex-parser": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+			"integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+			"peer": true
+		},
+		"node_modules/@webassemblyjs/helper-api-error": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+			"integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+			"peer": true
+		},
+		"node_modules/@webassemblyjs/helper-buffer": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+			"integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+			"peer": true
+		},
+		"node_modules/@webassemblyjs/helper-numbers": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+			"integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+			"peer": true,
+			"dependencies": {
+				"@webassemblyjs/floating-point-hex-parser": "1.13.2",
+				"@webassemblyjs/helper-api-error": "1.13.2",
+				"@xtuc/long": "4.2.2"
+			}
+		},
+		"node_modules/@webassemblyjs/helper-wasm-bytecode": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+			"integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+			"peer": true
+		},
+		"node_modules/@webassemblyjs/helper-wasm-section": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+			"integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+			"peer": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-buffer": "1.14.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/wasm-gen": "1.14.1"
+			}
+		},
+		"node_modules/@webassemblyjs/ieee754": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+			"integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+			"peer": true,
+			"dependencies": {
+				"@xtuc/ieee754": "^1.2.0"
+			}
+		},
+		"node_modules/@webassemblyjs/leb128": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+			"integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+			"peer": true,
+			"dependencies": {
+				"@xtuc/long": "4.2.2"
+			}
+		},
+		"node_modules/@webassemblyjs/utf8": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+			"integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+			"peer": true
+		},
+		"node_modules/@webassemblyjs/wasm-edit": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+			"integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+			"peer": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-buffer": "1.14.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/helper-wasm-section": "1.14.1",
+				"@webassemblyjs/wasm-gen": "1.14.1",
+				"@webassemblyjs/wasm-opt": "1.14.1",
+				"@webassemblyjs/wasm-parser": "1.14.1",
+				"@webassemblyjs/wast-printer": "1.14.1"
+			}
+		},
+		"node_modules/@webassemblyjs/wasm-gen": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+			"integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+			"peer": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/ieee754": "1.13.2",
+				"@webassemblyjs/leb128": "1.13.2",
+				"@webassemblyjs/utf8": "1.13.2"
+			}
+		},
+		"node_modules/@webassemblyjs/wasm-opt": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+			"integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+			"peer": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-buffer": "1.14.1",
+				"@webassemblyjs/wasm-gen": "1.14.1",
+				"@webassemblyjs/wasm-parser": "1.14.1"
+			}
+		},
+		"node_modules/@webassemblyjs/wasm-parser": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+			"integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+			"peer": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-api-error": "1.13.2",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/ieee754": "1.13.2",
+				"@webassemblyjs/leb128": "1.13.2",
+				"@webassemblyjs/utf8": "1.13.2"
+			}
+		},
+		"node_modules/@webassemblyjs/wast-printer": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+			"integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+			"peer": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.14.1",
+				"@xtuc/long": "4.2.2"
+			}
+		},
 		"node_modules/@xstate/fsm": {
 			"version": "1.6.5",
 			"license": "MIT"
+		},
+		"node_modules/@xtuc/ieee754": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+			"peer": true
+		},
+		"node_modules/@xtuc/long": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+			"peer": true
 		},
 		"node_modules/@zip.js/zip.js": {
 			"version": "2.7.45",
@@ -6448,7 +6623,6 @@
 		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/atomic-sleep": {
@@ -6490,7 +6664,6 @@
 		},
 		"node_modules/axios": {
 			"version": "1.7.7",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.6",
@@ -6754,8 +6927,9 @@
 			"license": "ISC"
 		},
 		"node_modules/browserslist": {
-			"version": "4.23.1",
-			"dev": true,
+			"version": "4.24.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+			"integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6770,12 +6944,11 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
-			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001629",
-				"electron-to-chromium": "^1.4.796",
-				"node-releases": "^2.0.14",
-				"update-browserslist-db": "^1.0.16"
+				"caniuse-lite": "^1.0.30001688",
+				"electron-to-chromium": "^1.5.73",
+				"node-releases": "^2.0.19",
+				"update-browserslist-db": "^1.1.1"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -6817,7 +6990,6 @@
 		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/bufferutil": {
@@ -6932,8 +7104,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001636",
-			"dev": true,
+			"version": "1.0.30001699",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001699.tgz",
+			"integrity": "sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6947,8 +7120,7 @@
 					"type": "github",
 					"url": "https://github.com/sponsors/ai"
 				}
-			],
-			"license": "CC-BY-4.0"
+			]
 		},
 		"node_modules/catharsis": {
 			"version": "0.9.0",
@@ -7064,6 +7236,15 @@
 			},
 			"engines": {
 				"node": ">=12.13.0"
+			}
+		},
+		"node_modules/chrome-trace-event": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+			"integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+			"peer": true,
+			"engines": {
+				"node": ">=6.0"
 			}
 		},
 		"node_modules/chromedriver": {
@@ -7263,7 +7444,6 @@
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"delayed-stream": "~1.0.0"
@@ -7274,7 +7454,6 @@
 		},
 		"node_modules/commander": {
 			"version": "2.20.3",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/commondir": {
@@ -7956,7 +8135,6 @@
 		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.4.0"
@@ -8075,9 +8253,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.807",
-			"dev": true,
-			"license": "ISC"
+			"version": "1.5.100",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.100.tgz",
+			"integrity": "sha512-u1z9VuzDXV86X2r3vAns0/5ojfXBue9o0+JDUDBKYqGLjxLkSqsSUoPU/6kW0gx76V44frHaf6Zo+QF74TQCMg=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -8142,6 +8320,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/enhanced-resolve": {
+			"version": "5.18.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+			"integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+			"peer": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"tapable": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/enquirer": {
@@ -8292,6 +8483,12 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/es-module-lexer": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+			"integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+			"peer": true
+		},
 		"node_modules/es-object-atoms": {
 			"version": "1.0.0",
 			"license": "MIT",
@@ -8409,9 +8606,9 @@
 			}
 		},
 		"node_modules/escalade": {
-			"version": "3.1.2",
-			"dev": true,
-			"license": "MIT",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"engines": {
 				"node": ">=6"
 			}
@@ -8762,7 +8959,6 @@
 		},
 		"node_modules/esrecurse": {
 			"version": "4.3.0",
-			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"estraverse": "^5.2.0"
@@ -8773,7 +8969,6 @@
 		},
 		"node_modules/estraverse": {
 			"version": "5.3.0",
-			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
@@ -8813,6 +9008,15 @@
 			"version": "4.0.7",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"peer": true,
+			"engines": {
+				"node": ">=0.8.x"
+			}
 		},
 		"node_modules/express": {
 			"version": "4.21.1",
@@ -8919,7 +9123,6 @@
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-diff": {
@@ -9034,7 +9237,6 @@
 		},
 		"node_modules/fast-uri": {
 			"version": "3.0.3",
-			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fast-url-parser": {
@@ -9321,7 +9523,6 @@
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.6",
-			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -9358,9 +9559,9 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+			"integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
@@ -9704,6 +9905,12 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/glob-to-regexp": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+			"peer": true
+		},
 		"node_modules/glob/node_modules/minimatch": {
 			"version": "5.1.6",
 			"dev": true,
@@ -9768,7 +9975,6 @@
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -10847,6 +11053,35 @@
 				"node": "*"
 			}
 		},
+		"node_modules/jest-worker": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+			"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
+		"node_modules/jest-worker/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"peer": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
 		"node_modules/jiti": {
 			"version": "2.4.0",
 			"dev": true,
@@ -11001,7 +11236,6 @@
 		},
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/json-schema-ref-resolver": {
@@ -11575,6 +11809,15 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/loader-runner": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+			"peer": true,
+			"engines": {
+				"node": ">=6.11.5"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"dev": true,
@@ -11964,6 +12207,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"peer": true
+		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"dev": true,
@@ -12285,6 +12534,12 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"peer": true
 		},
 		"node_modules/netmask": {
 			"version": "2.0.2",
@@ -12774,9 +13029,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.14",
-			"dev": true,
-			"license": "MIT"
+			"version": "2.0.19",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
 		},
 		"node_modules/normalize-package-data": {
 			"version": "2.5.0",
@@ -13597,7 +13852,6 @@
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
@@ -13952,7 +14206,6 @@
 		},
 		"node_modules/proxy-from-env": {
 			"version": "1.1.0",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/psl": {
@@ -14085,7 +14338,6 @@
 		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
@@ -14284,7 +14536,6 @@
 		},
 		"node_modules/require-from-string": {
 			"version": "2.0.2",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -14630,6 +14881,76 @@
 				"node": ">=v12.22.7"
 			}
 		},
+		"node_modules/schema-utils": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+			"integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+			"peer": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.9",
+				"ajv": "^8.9.0",
+				"ajv-formats": "^2.1.1",
+				"ajv-keywords": "^5.1.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			}
+		},
+		"node_modules/schema-utils/node_modules/ajv": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"peer": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/schema-utils/node_modules/ajv-formats": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+			"peer": true,
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/schema-utils/node_modules/ajv-keywords": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+			"peer": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3"
+			},
+			"peerDependencies": {
+				"ajv": "^8.8.2"
+			}
+		},
+		"node_modules/schema-utils/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"peer": true
+		},
 		"node_modules/secure-json-parse": {
 			"version": "2.7.0",
 			"license": "BSD-3-Clause"
@@ -14718,7 +15039,6 @@
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.2",
-			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"randombytes": "^2.1.0"
@@ -15014,7 +15334,6 @@
 		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
-			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -15030,7 +15349,6 @@
 		},
 		"node_modules/source-map-support": {
 			"version": "0.5.21",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"buffer-from": "^1.0.0",
@@ -15413,6 +15731,15 @@
 				"url": "https://opencollective.com/unts"
 			}
 		},
+		"node_modules/tapable": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/tar-fs": {
 			"version": "3.0.6",
 			"dev": true,
@@ -15575,7 +15902,6 @@
 		},
 		"node_modules/terser": {
 			"version": "5.31.1",
-			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
@@ -15588,6 +15914,40 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/terser-webpack-plugin": {
+			"version": "5.3.11",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz",
+			"integrity": "sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==",
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"jest-worker": "^27.4.5",
+				"schema-utils": "^4.3.0",
+				"serialize-javascript": "^6.0.2",
+				"terser": "^5.31.1"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependencies": {
+				"webpack": "^5.1.0"
+			},
+			"peerDependenciesMeta": {
+				"@swc/core": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"uglify-js": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/test-exclude": {
@@ -16228,6 +16588,18 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/unplugin": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.16.1.tgz",
+			"integrity": "sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==",
+			"dependencies": {
+				"acorn": "^8.14.0",
+				"webpack-virtual-modules": "^0.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/untildify": {
 			"version": "4.0.0",
 			"dev": true,
@@ -16237,8 +16609,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.16",
-			"dev": true,
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+			"integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -16253,10 +16626,9 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
-			"license": "MIT",
 			"dependencies": {
-				"escalade": "^3.1.2",
-				"picocolors": "^1.0.1"
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.1"
 			},
 			"bin": {
 				"update-browserslist-db": "cli.js"
@@ -16370,6 +16742,19 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/watchpack": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+			"integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+			"peer": true,
+			"dependencies": {
+				"glob-to-regexp": "^0.4.1",
+				"graceful-fs": "^4.1.2"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
 		"node_modules/wcwidth": {
 			"version": "1.0.1",
 			"dev": true,
@@ -16396,6 +16781,94 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/webpack": {
+			"version": "5.98.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
+			"integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
+			"peer": true,
+			"dependencies": {
+				"@types/eslint-scope": "^3.7.7",
+				"@types/estree": "^1.0.6",
+				"@webassemblyjs/ast": "^1.14.1",
+				"@webassemblyjs/wasm-edit": "^1.14.1",
+				"@webassemblyjs/wasm-parser": "^1.14.1",
+				"acorn": "^8.14.0",
+				"browserslist": "^4.24.0",
+				"chrome-trace-event": "^1.0.2",
+				"enhanced-resolve": "^5.17.1",
+				"es-module-lexer": "^1.2.1",
+				"eslint-scope": "5.1.1",
+				"events": "^3.2.0",
+				"glob-to-regexp": "^0.4.1",
+				"graceful-fs": "^4.2.11",
+				"json-parse-even-better-errors": "^2.3.1",
+				"loader-runner": "^4.2.0",
+				"mime-types": "^2.1.27",
+				"neo-async": "^2.6.2",
+				"schema-utils": "^4.3.0",
+				"tapable": "^2.1.1",
+				"terser-webpack-plugin": "^5.3.11",
+				"watchpack": "^2.4.1",
+				"webpack-sources": "^3.2.3"
+			},
+			"bin": {
+				"webpack": "bin/webpack.js"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependenciesMeta": {
+				"webpack-cli": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/webpack-sources": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+			"peer": true,
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/webpack-virtual-modules": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+			"integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="
+		},
+		"node_modules/webpack/node_modules/@types/estree": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+			"peer": true
+		},
+		"node_modules/webpack/node_modules/eslint-scope": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"peer": true,
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/webpack/node_modules/estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"peer": true,
+			"engines": {
+				"node": ">=4.0"
 			}
 		},
 		"node_modules/websocket": {
@@ -16837,6 +17310,26 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"packages/build-plugins": {
+			"version": "0.20.0-beta.2",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"axios": "^1.7.7",
+				"form-data": "^4.0.1",
+				"unplugin": "^1.14.1"
+			},
+			"devDependencies": {
+				"@types/chai": "^4.3.5",
+				"@types/mocha": "^10.0.1",
+				"chai": "^4.3.7",
+				"mocha": "^10.2.0",
+				"nyc": "^15.1.0",
+				"ts-node": "^10.9.1"
+			},
+			"peerDependencies": {
+				"webpack": "^5"
 			}
 		},
 		"packages/integration-tests": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"version": "0.20.0-beta.4",
 	"--workspaces": "Hardcoded so npm runs workspaces commands in order",
 	"workspaces": [
+		"packages/build-plugins",
 		"packages/web",
 		"packages/session-recorder",
 		"packages/integration-tests"

--- a/packages/build-plugins/.mocharc.integration.json
+++ b/packages/build-plugins/.mocharc.integration.json
@@ -1,0 +1,5 @@
+{
+	"extension": ["ts"],
+	"spec": "integration-test/**/*.test.ts",
+	"require": "ts-node/register"
+}

--- a/packages/build-plugins/integration-test/integration.test.ts
+++ b/packages/build-plugins/integration-test/integration.test.ts
@@ -1,18 +1,42 @@
+/**
+ *
+ * Copyright 2020-2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 import { expect } from 'chai'
-import { readFileSync, existsSync } from 'fs';
-import * as path from 'path';
-import { computeSourceMapIdFromFile } from '../src/utils';
+import { readFileSync, existsSync } from 'fs'
+import * as path from 'path'
+import { computeSourceMapIdFromFile } from '../src/utils'
 
 describe('integration-test setup', function () {
 	it('sample project dist/ folder exists', function () {
-		expect(existsSync('./integration-test/project/dist'), 'install and build the sample project before running this test suite').ok
+		expect(
+			existsSync('./integration-test/project/dist'),
+			'install and build the sample project before running this test suite',
+		).eq(true)
 	})
 })
 
 describe('webpack sourceMaps plugin', function () {
 	it('injects the correct code snippet only when a source map file was emitted', async function () {
-		await verifySourceMapIdInjectionDidOccur('./integration-test/project/dist/webpack-config-devtool-source-map-js/')
-		await verifySourceMapIdInjectionDidOccur('./integration-test/project/dist/webpack-config-devtool-hidden-source-map-js/')
+		await verifySourceMapIdInjectionDidOccur(
+			'./integration-test/project/dist/webpack-config-devtool-source-map-js/',
+		)
+		await verifySourceMapIdInjectionDidOccur(
+			'./integration-test/project/dist/webpack-config-devtool-hidden-source-map-js/',
+		)
 		await verifySourceMapIdInjectionDidNotOccur('./integration-test/project/dist/webpack-config-no-source-maps-js/')
 		await verifySourceMapIdInjectionDidNotOccur('./integration-test/project/dist/webpack-config-devtool-eval-js/')
 		await verifySourceMapIdInjectionDidNotOccur('./integration-test/project/dist/webpack-config-without-plugin-js/')
@@ -20,15 +44,15 @@ describe('webpack sourceMaps plugin', function () {
 })
 
 async function verifySourceMapIdInjectionDidOccur(distDirectory: string) {
-	let oldWindow = global.window;
+	const oldWindow = global.window
 
 	// Arrange:
 	// the code snippet expects a window object, so we set one artificially in the node test environment
-	(global.window as any) = {};
+	;(global.window as any) = {}
 
 	// Act: load the script that should have our injected code snippet
-	const mainJs = path.resolve(distDirectory + 'main.js');
-	await import(mainJs);
+	const mainJs = path.resolve(distDirectory + 'main.js')
+	await import(mainJs)
 
 	// Assert:
 	// This is a basic sanity check that the script will modify window.sourceMapIds when loaded
@@ -37,26 +61,24 @@ async function verifySourceMapIdInjectionDidOccur(distDirectory: string) {
 	// A real browser and real server are needed to perform further validation on the keys & values
 	// that will end up in window.sourceMapIds because of how the code snippet's regex works.
 	// There are playwright tests to handle this case.
-	expect((window as any).sourceMapIds).not.undefined;
+	expect((window as any).sourceMapIds).not.eq(undefined)
 
 	// Assert:
 	// check that the correct sourceMapId is included in the code snippet
-	const mainJsMap = path.resolve(distDirectory + 'main.js.map');
-	const expectedSourceMapId = await computeSourceMapIdFromFile(mainJsMap);
-	expect(readFileSync(mainJs).toString()).contains('window.sourceMapIds\[s] = \'' + expectedSourceMapId + '\'');
-
-	(global.window as any) = oldWindow;
+	const mainJsMap = path.resolve(distDirectory + 'main.js.map')
+	const expectedSourceMapId = await computeSourceMapIdFromFile(mainJsMap)
+	expect(readFileSync(mainJs).toString()).contains("window.sourceMapIds[s] = '" + expectedSourceMapId + "'")
+	;(global.window as any) = oldWindow
 }
 
 async function verifySourceMapIdInjectionDidNotOccur(distDirectory: string) {
-	let oldWindow = global.window;
-	(global.window as any) = {};
+	const oldWindow = global.window
+	;(global.window as any) = {}
 
-	const mainJs = path.resolve(distDirectory + 'main.js');
-	await import(mainJs);
+	const mainJs = path.resolve(distDirectory + 'main.js')
+	await import(mainJs)
 
-	expect((window as any).sourceMapIds).undefined;
-	expect(readFileSync(mainJs).toString()).not.contains('window.sourceMapIds');
-
-	(global.window as any) = oldWindow;
+	expect((window as any).sourceMapIds).eq(undefined)
+	expect(readFileSync(mainJs).toString()).not.contains('window.sourceMapIds')
+	;(global.window as any) = oldWindow
 }

--- a/packages/build-plugins/integration-test/integration.test.ts
+++ b/packages/build-plugins/integration-test/integration.test.ts
@@ -1,0 +1,62 @@
+import { expect } from 'chai'
+import { readFileSync, existsSync } from 'fs';
+import * as path from 'path';
+import { computeSourceMapIdFromFile } from '../src/utils';
+
+describe('integration-test setup', function () {
+	it('sample project dist/ folder exists', function () {
+		expect(existsSync('./integration-test/project/dist'), 'install and build the sample project before running this test suite').ok
+	})
+})
+
+describe('webpack sourceMaps plugin', function () {
+	it('injects the correct code snippet only when a source map file was emitted', async function () {
+		await verifySourceMapIdInjectionDidOccur('./integration-test/project/dist/webpack-config-devtool-source-map-js/')
+		await verifySourceMapIdInjectionDidOccur('./integration-test/project/dist/webpack-config-devtool-hidden-source-map-js/')
+		await verifySourceMapIdInjectionDidNotOccur('./integration-test/project/dist/webpack-config-no-source-maps-js/')
+		await verifySourceMapIdInjectionDidNotOccur('./integration-test/project/dist/webpack-config-devtool-eval-js/')
+		await verifySourceMapIdInjectionDidNotOccur('./integration-test/project/dist/webpack-config-without-plugin-js/')
+	})
+})
+
+async function verifySourceMapIdInjectionDidOccur(distDirectory: string) {
+	let oldWindow = global.window;
+
+	// Arrange:
+	// the code snippet expects a window object, so we set one artificially in the node test environment
+	(global.window as any) = {};
+
+	// Act: load the script that should have our injected code snippet
+	const mainJs = path.resolve(distDirectory + 'main.js');
+	await import(mainJs);
+
+	// Assert:
+	// This is a basic sanity check that the script will modify window.sourceMapIds when loaded
+	// The code snippet does not support node environments, so sourceMapIds is just an empty object here.
+	//
+	// A real browser and real server are needed to perform further validation on the keys & values
+	// that will end up in window.sourceMapIds because of how the code snippet's regex works.
+	// There are playwright tests to handle this case.
+	expect((window as any).sourceMapIds).not.undefined;
+
+	// Assert:
+	// check that the correct sourceMapId is included in the code snippet
+	const mainJsMap = path.resolve(distDirectory + 'main.js.map');
+	const expectedSourceMapId = await computeSourceMapIdFromFile(mainJsMap);
+	expect(readFileSync(mainJs).toString()).contains('window.sourceMapIds\[s] = \'' + expectedSourceMapId + '\'');
+
+	(global.window as any) = oldWindow;
+}
+
+async function verifySourceMapIdInjectionDidNotOccur(distDirectory: string) {
+	let oldWindow = global.window;
+	(global.window as any) = {};
+
+	const mainJs = path.resolve(distDirectory + 'main.js');
+	await import(mainJs);
+
+	expect((window as any).sourceMapIds).undefined;
+	expect(readFileSync(mainJs).toString()).not.contains('window.sourceMapIds');
+
+	(global.window as any) = oldWindow;
+}

--- a/packages/build-plugins/integration-test/project/package-lock.json
+++ b/packages/build-plugins/integration-test/project/package-lock.json
@@ -1,0 +1,1495 @@
+{
+	"name": "build-plugins-test-project",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "build-plugins-test-project",
+			"devDependencies": {
+				"@splunk/olly-web-build-plugins": "file://../../",
+				"webpack": "^5.76.0",
+				"webpack-cli": "^6.0.1"
+			}
+		},
+		"../..": {
+			"name": "@splunk/olly-web-build-plugins",
+			"version": "0.20.0-beta.2",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"axios": "^1.7.7",
+				"form-data": "^4.0.1",
+				"unplugin": "^1.14.1"
+			},
+			"devDependencies": {
+				"@types/chai": "^4.3.5",
+				"@types/mocha": "^10.0.1",
+				"chai": "^4.3.7",
+				"mocha": "^10.2.0",
+				"nyc": "^15.1.0",
+				"ts-node": "^10.9.1"
+			},
+			"peerDependencies": {
+				"webpack": "^5"
+			}
+		},
+		"node_modules/@discoveryjs/json-ext": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
+			"integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.17.0"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/set-array": "^1.2.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/set-array": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/source-map": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+			"integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+			"dev": true
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@splunk/olly-web-build-plugins": {
+			"resolved": "../..",
+			"link": true
+		},
+		"node_modules/@types/eslint": {
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+			"integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "*",
+				"@types/json-schema": "*"
+			}
+		},
+		"node_modules/@types/eslint-scope": {
+			"version": "3.7.7",
+			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+			"dev": true,
+			"dependencies": {
+				"@types/eslint": "*",
+				"@types/estree": "*"
+			}
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+			"dev": true
+		},
+		"node_modules/@types/json-schema": {
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"dev": true
+		},
+		"node_modules/@types/node": {
+			"version": "22.13.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.2.tgz",
+			"integrity": "sha512-Z+r8y3XL9ZpI2EY52YYygAFmo2/oWfNSj4BCpAXE2McAexDk8VcnBMGC9Djn9gTKt4d2T/hhXqmPzo4hfIXtTg==",
+			"dev": true,
+			"dependencies": {
+				"undici-types": "~6.20.0"
+			}
+		},
+		"node_modules/@webassemblyjs/ast": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+			"integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+			"dev": true,
+			"dependencies": {
+				"@webassemblyjs/helper-numbers": "1.13.2",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+			}
+		},
+		"node_modules/@webassemblyjs/floating-point-hex-parser": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+			"integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+			"dev": true
+		},
+		"node_modules/@webassemblyjs/helper-api-error": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+			"integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+			"dev": true
+		},
+		"node_modules/@webassemblyjs/helper-buffer": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+			"integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+			"dev": true
+		},
+		"node_modules/@webassemblyjs/helper-numbers": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+			"integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+			"dev": true,
+			"dependencies": {
+				"@webassemblyjs/floating-point-hex-parser": "1.13.2",
+				"@webassemblyjs/helper-api-error": "1.13.2",
+				"@xtuc/long": "4.2.2"
+			}
+		},
+		"node_modules/@webassemblyjs/helper-wasm-bytecode": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+			"integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+			"dev": true
+		},
+		"node_modules/@webassemblyjs/helper-wasm-section": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+			"integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+			"dev": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-buffer": "1.14.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/wasm-gen": "1.14.1"
+			}
+		},
+		"node_modules/@webassemblyjs/ieee754": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+			"integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+			"dev": true,
+			"dependencies": {
+				"@xtuc/ieee754": "^1.2.0"
+			}
+		},
+		"node_modules/@webassemblyjs/leb128": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+			"integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+			"dev": true,
+			"dependencies": {
+				"@xtuc/long": "4.2.2"
+			}
+		},
+		"node_modules/@webassemblyjs/utf8": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+			"integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+			"dev": true
+		},
+		"node_modules/@webassemblyjs/wasm-edit": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+			"integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+			"dev": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-buffer": "1.14.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/helper-wasm-section": "1.14.1",
+				"@webassemblyjs/wasm-gen": "1.14.1",
+				"@webassemblyjs/wasm-opt": "1.14.1",
+				"@webassemblyjs/wasm-parser": "1.14.1",
+				"@webassemblyjs/wast-printer": "1.14.1"
+			}
+		},
+		"node_modules/@webassemblyjs/wasm-gen": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+			"integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+			"dev": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/ieee754": "1.13.2",
+				"@webassemblyjs/leb128": "1.13.2",
+				"@webassemblyjs/utf8": "1.13.2"
+			}
+		},
+		"node_modules/@webassemblyjs/wasm-opt": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+			"integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+			"dev": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-buffer": "1.14.1",
+				"@webassemblyjs/wasm-gen": "1.14.1",
+				"@webassemblyjs/wasm-parser": "1.14.1"
+			}
+		},
+		"node_modules/@webassemblyjs/wasm-parser": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+			"integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+			"dev": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-api-error": "1.13.2",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/ieee754": "1.13.2",
+				"@webassemblyjs/leb128": "1.13.2",
+				"@webassemblyjs/utf8": "1.13.2"
+			}
+		},
+		"node_modules/@webassemblyjs/wast-printer": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+			"integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+			"dev": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.14.1",
+				"@xtuc/long": "4.2.2"
+			}
+		},
+		"node_modules/@webpack-cli/configtest": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
+			"integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18.12.0"
+			},
+			"peerDependencies": {
+				"webpack": "^5.82.0",
+				"webpack-cli": "6.x.x"
+			}
+		},
+		"node_modules/@webpack-cli/info": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
+			"integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=18.12.0"
+			},
+			"peerDependencies": {
+				"webpack": "^5.82.0",
+				"webpack-cli": "6.x.x"
+			}
+		},
+		"node_modules/@webpack-cli/serve": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
+			"integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
+			"dev": true,
+			"engines": {
+				"node": ">=18.12.0"
+			},
+			"peerDependencies": {
+				"webpack": "^5.82.0",
+				"webpack-cli": "6.x.x"
+			},
+			"peerDependenciesMeta": {
+				"webpack-dev-server": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@xtuc/ieee754": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+			"dev": true
+		},
+		"node_modules/@xtuc/long": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+			"dev": true
+		},
+		"node_modules/acorn": {
+			"version": "8.14.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+			"dev": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+			"dev": true,
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ajv-formats/node_modules/ajv": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true
+		},
+		"node_modules/ajv-keywords": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+			"dev": true,
+			"peerDependencies": {
+				"ajv": "^6.9.1"
+			}
+		},
+		"node_modules/browserslist": {
+			"version": "4.24.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+			"integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"caniuse-lite": "^1.0.30001688",
+				"electron-to-chromium": "^1.5.73",
+				"node-releases": "^2.0.19",
+				"update-browserslist-db": "^1.1.1"
+			},
+			"bin": {
+				"browserslist": "cli.js"
+			},
+			"engines": {
+				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
+		"node_modules/buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true
+		},
+		"node_modules/caniuse-lite": {
+			"version": "1.0.30001699",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001699.tgz",
+			"integrity": "sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			]
+		},
+		"node_modules/chrome-trace-event": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+			"integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0"
+			}
+		},
+		"node_modules/clone-deep": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+			"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+			"dev": true,
+			"dependencies": {
+				"is-plain-object": "^2.0.4",
+				"kind-of": "^6.0.2",
+				"shallow-clone": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/colorette": {
+			"version": "2.0.20",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+			"dev": true
+		},
+		"node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/electron-to-chromium": {
+			"version": "1.5.98",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.98.tgz",
+			"integrity": "sha512-bI/LbtRBxU2GzK7KK5xxFd2y9Lf9XguHooPYbcXWy6wUoT8NMnffsvRhPmSeUHLSDKAEtKuTaEtK4Ms15zkIEA==",
+			"dev": true
+		},
+		"node_modules/enhanced-resolve": {
+			"version": "5.18.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+			"integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"tapable": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/envinfo": {
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
+			"integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
+			"dev": true,
+			"bin": {
+				"envinfo": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+			"integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+			"dev": true
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/eslint-scope": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"dev": true,
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/esrecurse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
+			"dependencies": {
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esrecurse/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.x"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true
+		},
+		"node_modules/fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true
+		},
+		"node_modules/fast-uri": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+			"integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			]
+		},
+		"node_modules/fastest-levenshtein": {
+			"version": "1.0.16",
+			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+			"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4.9.1"
+			}
+		},
+		"node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/flat": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+			"dev": true,
+			"bin": {
+				"flat": "cli.js"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/glob-to-regexp": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+			"dev": true
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/import-local": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+			"integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+			"dev": true,
+			"dependencies": {
+				"pkg-dir": "^4.2.0",
+				"resolve-cwd": "^3.0.0"
+			},
+			"bin": {
+				"import-local-fixture": "fixtures/cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/interpret": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+			"integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/is-core-module": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+			"dev": true,
+			"dependencies": {
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"dependencies": {
+				"isobject": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true
+		},
+		"node_modules/isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/jest-worker": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+			"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
+		"node_modules/json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
+		},
+		"node_modules/kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/loader-runner": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.11.5"
+			}
+		},
+		"node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"dev": true
+		},
+		"node_modules/node-releases": {
+			"version": "2.0.19",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+			"dev": true
+		},
+		"node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true
+		},
+		"node_modules/pkg-dir": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"node_modules/rechoir": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+			"integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+			"dev": true,
+			"dependencies": {
+				"resolve": "^1.20.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "1.22.10",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+			"integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+			"dev": true,
+			"dependencies": {
+				"is-core-module": "^2.16.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/resolve-cwd": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+			"dev": true,
+			"dependencies": {
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/schema-utils": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+			"dev": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.8",
+				"ajv": "^6.12.5",
+				"ajv-keywords": "^3.5.2"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			}
+		},
+		"node_modules/serialize-javascript": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+			"dev": true,
+			"dependencies": {
+				"randombytes": "^2.1.0"
+			}
+		},
+		"node_modules/shallow-clone": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+			"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+			"dev": true,
+			"dependencies": {
+				"kind-of": "^6.0.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/tapable": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/terser": {
+			"version": "5.38.2",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.38.2.tgz",
+			"integrity": "sha512-w8CXxxbFA5zfNsR/i8HZq5bvn18AK0O9jj7hyo1YqkovLxEFa0uP0LCVGZRqiRaKRFxXhELBp8SteeAjEnfeJg==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.8.2",
+				"commander": "^2.20.0",
+				"source-map-support": "~0.5.20"
+			},
+			"bin": {
+				"terser": "bin/terser"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/terser-webpack-plugin": {
+			"version": "5.3.11",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz",
+			"integrity": "sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"jest-worker": "^27.4.5",
+				"schema-utils": "^4.3.0",
+				"serialize-javascript": "^6.0.2",
+				"terser": "^5.31.1"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependencies": {
+				"webpack": "^5.1.0"
+			},
+			"peerDependenciesMeta": {
+				"@swc/core": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"uglify-js": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/terser-webpack-plugin/node_modules/ajv": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3"
+			},
+			"peerDependencies": {
+				"ajv": "^8.8.2"
+			}
+		},
+		"node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true
+		},
+		"node_modules/terser-webpack-plugin/node_modules/schema-utils": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+			"integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+			"dev": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.9",
+				"ajv": "^8.9.0",
+				"ajv-formats": "^2.1.1",
+				"ajv-keywords": "^5.1.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+			"dev": true
+		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+			"integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.1"
+			},
+			"bin": {
+				"update-browserslist-db": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/watchpack": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+			"integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+			"dev": true,
+			"dependencies": {
+				"glob-to-regexp": "^0.4.1",
+				"graceful-fs": "^4.1.2"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/webpack": {
+			"version": "5.97.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+			"integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
+			"dev": true,
+			"dependencies": {
+				"@types/eslint-scope": "^3.7.7",
+				"@types/estree": "^1.0.6",
+				"@webassemblyjs/ast": "^1.14.1",
+				"@webassemblyjs/wasm-edit": "^1.14.1",
+				"@webassemblyjs/wasm-parser": "^1.14.1",
+				"acorn": "^8.14.0",
+				"browserslist": "^4.24.0",
+				"chrome-trace-event": "^1.0.2",
+				"enhanced-resolve": "^5.17.1",
+				"es-module-lexer": "^1.2.1",
+				"eslint-scope": "5.1.1",
+				"events": "^3.2.0",
+				"glob-to-regexp": "^0.4.1",
+				"graceful-fs": "^4.2.11",
+				"json-parse-even-better-errors": "^2.3.1",
+				"loader-runner": "^4.2.0",
+				"mime-types": "^2.1.27",
+				"neo-async": "^2.6.2",
+				"schema-utils": "^3.2.0",
+				"tapable": "^2.1.1",
+				"terser-webpack-plugin": "^5.3.10",
+				"watchpack": "^2.4.1",
+				"webpack-sources": "^3.2.3"
+			},
+			"bin": {
+				"webpack": "bin/webpack.js"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependenciesMeta": {
+				"webpack-cli": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/webpack-cli": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
+			"integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
+			"dev": true,
+			"dependencies": {
+				"@discoveryjs/json-ext": "^0.6.1",
+				"@webpack-cli/configtest": "^3.0.1",
+				"@webpack-cli/info": "^3.0.1",
+				"@webpack-cli/serve": "^3.0.1",
+				"colorette": "^2.0.14",
+				"commander": "^12.1.0",
+				"cross-spawn": "^7.0.3",
+				"envinfo": "^7.14.0",
+				"fastest-levenshtein": "^1.0.12",
+				"import-local": "^3.0.2",
+				"interpret": "^3.1.1",
+				"rechoir": "^0.8.0",
+				"webpack-merge": "^6.0.1"
+			},
+			"bin": {
+				"webpack-cli": "bin/cli.js"
+			},
+			"engines": {
+				"node": ">=18.12.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependencies": {
+				"webpack": "^5.82.0"
+			},
+			"peerDependenciesMeta": {
+				"webpack-bundle-analyzer": {
+					"optional": true
+				},
+				"webpack-dev-server": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/webpack-cli/node_modules/commander": {
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/webpack-merge": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+			"integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
+			"dev": true,
+			"dependencies": {
+				"clone-deep": "^4.0.1",
+				"flat": "^5.0.2",
+				"wildcard": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/webpack-sources": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/wildcard": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+			"integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
+			"dev": true
+		}
+	}
+}

--- a/packages/build-plugins/integration-test/project/package.json
+++ b/packages/build-plugins/integration-test/project/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "build-plugins-test-project",
+	"description": "a helper project for testing integration of plugins with build tools using different configurations",
+	"private": true,
+	"scripts": {
+		"compile": "npm-run-all -s compile:*",
+		"compile:webpack": "find . -name \"webpack.config.*\" -print0 | xargs -t -0 -I {} npx webpack --config {}"
+	},
+	"devDependencies": {
+		"webpack": "^5.76.0",
+		"webpack-cli": "^6.0.1",
+		"@splunk/olly-web-build-plugins": "file://../../"
+	}
+}

--- a/packages/build-plugins/integration-test/project/src/common/helpers.js
+++ b/packages/build-plugins/integration-test/project/src/common/helpers.js
@@ -20,7 +20,8 @@ export function sharedHelperFunction(value1, value2) {
 	return result
 }
 
-export function sharedHelperFunctionThatThrowsError(value) {
+export function sharedHelperFunctionThatThrowsError() {
+	/* eslint-disable no-undef */
 	return thisFunctionDoesNotExist()
 }
 

--- a/packages/build-plugins/integration-test/project/src/common/helpers.js
+++ b/packages/build-plugins/integration-test/project/src/common/helpers.js
@@ -1,0 +1,12 @@
+export function sharedHelperFunction(value1, value2) {
+	const result = value1 + value2;
+	return result;
+}
+
+export function sharedHelperFunctionThatThrowsError(value) {
+	return thisFunctionDoesNotExist();
+}
+
+export function otherHelperFunction(value) {
+	return String(value);
+}

--- a/packages/build-plugins/integration-test/project/src/common/helpers.js
+++ b/packages/build-plugins/integration-test/project/src/common/helpers.js
@@ -1,12 +1,29 @@
+/**
+ *
+ * Copyright 2020-2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 export function sharedHelperFunction(value1, value2) {
-	const result = value1 + value2;
-	return result;
+	const result = value1 + value2
+	return result
 }
 
 export function sharedHelperFunctionThatThrowsError(value) {
-	return thisFunctionDoesNotExist();
+	return thisFunctionDoesNotExist()
 }
 
 export function otherHelperFunction(value) {
-	return String(value);
+	return String(value)
 }

--- a/packages/build-plugins/integration-test/project/src/index.js
+++ b/packages/build-plugins/integration-test/project/src/index.js
@@ -1,3 +1,20 @@
+/**
+ *
+ * Copyright 2020-2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 import { sharedHelperFunction, sharedHelperFunctionThatThrowsError } from './common/helpers'
 
 function globalFunction() {

--- a/packages/build-plugins/integration-test/project/src/index.js
+++ b/packages/build-plugins/integration-test/project/src/index.js
@@ -1,0 +1,14 @@
+import { sharedHelperFunction, sharedHelperFunctionThatThrowsError } from './common/helpers'
+
+function globalFunction() {
+	const value1 = 1
+	const value2 = 2
+	console.log('running index.js of the build-plugins sample project', sharedHelperFunction(value1, value2))
+}
+
+function globalFunctionThatThrowsError() {
+	sharedHelperFunctionThatThrowsError(5)
+}
+
+window.globalFunction = globalFunction
+window.globalFunctionThatThrowsError = globalFunctionThatThrowsError

--- a/packages/build-plugins/integration-test/project/src/index.js
+++ b/packages/build-plugins/integration-test/project/src/index.js
@@ -24,7 +24,7 @@ function globalFunction() {
 }
 
 function globalFunctionThatThrowsError() {
-	sharedHelperFunctionThatThrowsError(5)
+	sharedHelperFunctionThatThrowsError()
 }
 
 window.globalFunction = globalFunction

--- a/packages/build-plugins/integration-test/project/src/other-entry.js
+++ b/packages/build-plugins/integration-test/project/src/other-entry.js
@@ -1,3 +1,20 @@
+/**
+ *
+ * Copyright 2020-2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 import { sharedHelperFunction, otherHelperFunction } from './common/helpers'
 
 const result = sharedHelperFunction(1, 2)

--- a/packages/build-plugins/integration-test/project/src/other-entry.js
+++ b/packages/build-plugins/integration-test/project/src/other-entry.js
@@ -1,0 +1,8 @@
+import { sharedHelperFunction, otherHelperFunction } from './common/helpers'
+
+const result = sharedHelperFunction(1, 2)
+otherHelperFunction(result)
+
+window.globalFunctionFromOtherEntry = function () {
+	console.log('executing function in other-entry.js', otherHelperFunction(5))
+}

--- a/packages/build-plugins/integration-test/project/webpack-utils.js
+++ b/packages/build-plugins/integration-test/project/webpack-utils.js
@@ -1,16 +1,31 @@
-const path = require('path');
+/**
+ *
+ * Copyright 2020-2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const path = require('path')
 module.exports = {
-	getBaseConfig: (configFilename) => {
-		return {
-			entry: {
-				main: './src/index.js',
-				other: './src/other-entry.js',
-			},
-			output: {
-				filename: '[name].js',
-				path: path.resolve(__dirname, 'dist/' + path.basename(configFilename).replaceAll('.', '-')),
-			},
-			mode: 'production'
-		}
-	}
+	getBaseConfig: (configFilename) => ({
+		entry: {
+			main: './src/index.js',
+			other: './src/other-entry.js',
+		},
+		output: {
+			filename: '[name].js',
+			path: path.resolve(__dirname, 'dist/' + path.basename(configFilename).replaceAll('.', '-')),
+		},
+		mode: 'production',
+	}),
 }

--- a/packages/build-plugins/integration-test/project/webpack-utils.js
+++ b/packages/build-plugins/integration-test/project/webpack-utils.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+/* eslint-disable */
 const path = require('path')
 module.exports = {
 	getBaseConfig: (configFilename) => ({

--- a/packages/build-plugins/integration-test/project/webpack-utils.js
+++ b/packages/build-plugins/integration-test/project/webpack-utils.js
@@ -1,0 +1,16 @@
+const path = require('path');
+module.exports = {
+	getBaseConfig: (configFilename) => {
+		return {
+			entry: {
+				main: './src/index.js',
+				other: './src/other-entry.js',
+			},
+			output: {
+				filename: '[name].js',
+				path: path.resolve(__dirname, 'dist/' + path.basename(configFilename).replaceAll('.', '-')),
+			},
+			mode: 'production'
+		}
+	}
+}

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.eval.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.eval.js
@@ -1,0 +1,19 @@
+const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
+const path = require('path');
+const { getBaseConfig } = require('./webpack-utils');
+
+module.exports = {
+	...getBaseConfig(__filename),
+	devtool: 'eval',
+	plugins: [
+		ollyWebWebpackPlugin({
+			sourceMaps: {
+				applicationName: 'sample-app',
+				disableUpload: true,
+				realm: 'us0',
+				token: '<token>',
+				version: '0.1.0'
+			}
+		})
+	]
+};

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.eval.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.eval.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+/* eslint-disable */
 const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
 const path = require('path')
 const { getBaseConfig } = require('./webpack-utils')

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.eval.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.eval.js
@@ -1,6 +1,23 @@
+/**
+ *
+ * Copyright 2020-2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
-const path = require('path');
-const { getBaseConfig } = require('./webpack-utils');
+const path = require('path')
+const { getBaseConfig } = require('./webpack-utils')
 
 module.exports = {
 	...getBaseConfig(__filename),
@@ -12,8 +29,8 @@ module.exports = {
 				disableUpload: true,
 				realm: 'us0',
 				token: '<token>',
-				version: '0.1.0'
-			}
-		})
-	]
-};
+				version: '0.1.0',
+			},
+		}),
+	],
+}

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.hidden-source-map.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.hidden-source-map.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+/* eslint-disable */
 const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
 const path = require('path')
 const { getBaseConfig } = require('./webpack-utils')

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.hidden-source-map.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.hidden-source-map.js
@@ -1,6 +1,23 @@
+/**
+ *
+ * Copyright 2020-2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
-const path = require('path');
-const { getBaseConfig } = require('./webpack-utils');
+const path = require('path')
+const { getBaseConfig } = require('./webpack-utils')
 
 module.exports = {
 	...getBaseConfig(__filename),
@@ -12,8 +29,8 @@ module.exports = {
 				disableUpload: true,
 				realm: 'us0',
 				token: '<token>',
-				version: '0.1.0'
-			}
-		})
-	]
-};
+				version: '0.1.0',
+			},
+		}),
+	],
+}

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.hidden-source-map.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.hidden-source-map.js
@@ -1,0 +1,19 @@
+const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
+const path = require('path');
+const { getBaseConfig } = require('./webpack-utils');
+
+module.exports = {
+	...getBaseConfig(__filename),
+	devtool: 'hidden-source-map',
+	plugins: [
+		ollyWebWebpackPlugin({
+			sourceMaps: {
+				applicationName: 'sample-app',
+				disableUpload: true,
+				realm: 'us0',
+				token: '<token>',
+				version: '0.1.0'
+			}
+		})
+	]
+};

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.source-map.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.source-map.js
@@ -1,0 +1,19 @@
+const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
+const path = require('path');
+const { getBaseConfig } = require('./webpack-utils');
+
+module.exports = {
+	...getBaseConfig(__filename),
+	devtool: 'source-map',
+	plugins: [
+		ollyWebWebpackPlugin({
+			sourceMaps: {
+				applicationName: 'sample-app',
+				disableUpload: true,
+				realm: 'us0',
+				token: '<token>',
+				version: '0.1.0'
+			}
+		})
+	]
+};

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.source-map.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.source-map.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+/* eslint-disable */
 const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
 const path = require('path')
 const { getBaseConfig } = require('./webpack-utils')

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.source-map.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.source-map.js
@@ -1,6 +1,23 @@
+/**
+ *
+ * Copyright 2020-2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
-const path = require('path');
-const { getBaseConfig } = require('./webpack-utils');
+const path = require('path')
+const { getBaseConfig } = require('./webpack-utils')
 
 module.exports = {
 	...getBaseConfig(__filename),
@@ -12,8 +29,8 @@ module.exports = {
 				disableUpload: true,
 				realm: 'us0',
 				token: '<token>',
-				version: '0.1.0'
-			}
-		})
-	]
-};
+				version: '0.1.0',
+			},
+		}),
+	],
+}

--- a/packages/build-plugins/integration-test/project/webpack.config.no-source-maps.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.no-source-maps.js
@@ -1,6 +1,23 @@
+/**
+ *
+ * Copyright 2020-2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
-const path = require('path');
-const { getBaseConfig } = require('./webpack-utils');
+const path = require('path')
+const { getBaseConfig } = require('./webpack-utils')
 
 module.exports = {
 	...getBaseConfig(__filename),
@@ -11,8 +28,8 @@ module.exports = {
 				disableUpload: true,
 				realm: 'us0',
 				token: '<token>',
-				version: '0.1.0'
-			}
-		})
-	]
-};
+				version: '0.1.0',
+			},
+		}),
+	],
+}

--- a/packages/build-plugins/integration-test/project/webpack.config.no-source-maps.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.no-source-maps.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+/* eslint-disable */
 const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
 const path = require('path')
 const { getBaseConfig } = require('./webpack-utils')

--- a/packages/build-plugins/integration-test/project/webpack.config.no-source-maps.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.no-source-maps.js
@@ -1,0 +1,18 @@
+const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
+const path = require('path');
+const { getBaseConfig } = require('./webpack-utils');
+
+module.exports = {
+	...getBaseConfig(__filename),
+	plugins: [
+		ollyWebWebpackPlugin({
+			sourceMaps: {
+				applicationName: 'sample-app',
+				disableUpload: true,
+				realm: 'us0',
+				token: '<token>',
+				version: '0.1.0'
+			}
+		})
+	]
+};

--- a/packages/build-plugins/integration-test/project/webpack.config.without-plugin.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.without-plugin.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+/* eslint-disable */
 const path = require('path')
 const { getBaseConfig } = require('./webpack-utils')
 

--- a/packages/build-plugins/integration-test/project/webpack.config.without-plugin.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.without-plugin.js
@@ -1,7 +1,24 @@
-const path = require('path');
-const { getBaseConfig } = require('./webpack-utils');
+/**
+ *
+ * Copyright 2020-2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const path = require('path')
+const { getBaseConfig } = require('./webpack-utils')
 
 module.exports = {
 	...getBaseConfig(__filename),
-	devtool: 'source-map'
-};
+	devtool: 'source-map',
+}

--- a/packages/build-plugins/integration-test/project/webpack.config.without-plugin.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.without-plugin.js
@@ -1,0 +1,7 @@
+const path = require('path');
+const { getBaseConfig } = require('./webpack-utils');
+
+module.exports = {
+	...getBaseConfig(__filename),
+	devtool: 'source-map'
+};

--- a/packages/build-plugins/package.json
+++ b/packages/build-plugins/package.json
@@ -7,7 +7,10 @@
 	"scripts": {
 		"compile": "npm-run-all -s compile:*",
 		"compile:tsc": "tsc --build tsconfig.cjs.json tsconfig.esm.json",
-		"test:unit:ci": "env TS_NODE_TRANSPILE_ONLY=true TS_NODE_PROJECT=tsconfig.cjs.json nyc mocha"
+		"pretest:plugin:integration": "cd integration-test/project && npm install && npm run compile",
+		"test:unit:ci": "npm-run-all -s test:plugin:*",
+		"test:plugin:unit": "env TS_NODE_TRANSPILE_ONLY=true TS_NODE_PROJECT=tsconfig.cjs.json nyc mocha",
+		"test:plugin:integration": "env TS_NODE_TRANSPILE_ONLY=true TS_NODE_PROJECT=tsconfig.cjs.json mocha --config .mocharc.integration.json"
 	},
 	"author": "Splunk Observability Instrumentals Team <ssg-observability-instrumentals-npm@splunk.com>",
 	"license": "Apache-2.0",
@@ -41,7 +44,7 @@
 		"ts-node": "^10.9.1"
 	},
 	"peerDependencies": {
-		"webpack": "^4 || ^5"
+		"webpack": "^5"
 	},
 	"bugs": {
 		"url": "https://github.com/signalfx/splunk-otel-js-browser/issues"

--- a/packages/build-plugins/package.json
+++ b/packages/build-plugins/package.json
@@ -5,9 +5,9 @@
 	"description": "Build plugins for users of @splunk/otel-web",
 	"repository": "github:signalfx/splunk-otel-js-browser",
 	"scripts": {
-		"compile": "npm-run-all -s compile:*",
+		"compile": "npm-run-all -s compile:* && cd integration-test",
 		"compile:tsc": "tsc --build tsconfig.cjs.json tsconfig.esm.json",
-		"pretest:plugin:integration": "cd integration-test/project && npm install && npm run compile",
+		"compile:integration": "cd integration-test/project && npm install && npm run compile",
 		"test:unit:ci": "npm-run-all -s test:plugin:*",
 		"test:plugin:unit": "env TS_NODE_TRANSPILE_ONLY=true TS_NODE_PROJECT=tsconfig.cjs.json nyc mocha",
 		"test:plugin:integration": "env TS_NODE_TRANSPILE_ONLY=true TS_NODE_PROJECT=tsconfig.cjs.json mocha --config .mocharc.integration.json"

--- a/packages/build-plugins/src/utils.ts
+++ b/packages/build-plugins/src/utils.ts
@@ -48,7 +48,7 @@ export async function computeSourceMapIdFromFile(sourceMapFilePath: string): Pro
 	return shaToSourceMapId(sha)
 }
 
-const SNIPPET_TEMPLATE = `;if (typeof window === 'object') { window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\\/\\/[^\\s]+?(?::\\d+)?(?=:[\\d]+:[\\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '__SOURCE_MAP_ID_PLACEHOLDER__';}};\n`
+const SNIPPET_TEMPLATE = `;if (typeof window === 'object') { window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\\/\\/[^\\s]+?(?::\\d+)?(?=:[\\d]+:[\\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '__SOURCE_MAP_ID_PLACEHOLDER__';}};`
 
 export function getCodeSnippet(sourceMapId: string): string {
 	return SNIPPET_TEMPLATE.replace('__SOURCE_MAP_ID_PLACEHOLDER__', sourceMapId)

--- a/packages/build-plugins/tsconfig.json
+++ b/packages/build-plugins/tsconfig.json
@@ -1,5 +1,5 @@
 {
 	"extends": "./tsconfig.base.json",
-	"include": ["src/**/*.ts", "test/**/*.ts"],
+	"include": ["src/**/*.ts", "test/**/*.ts", "integration-test/**/*.ts"],
 	"exclude": ["node_modules"]
 }

--- a/packages/integration-tests/src/server/server.ts
+++ b/packages/integration-tests/src/server/server.ts
@@ -60,6 +60,12 @@ fastify.register(fastifyStatic, {
 	decorateReply: false,
 })
 
+fastify.register(fastifyStatic, {
+	root: path.join(__dirname, '../../../build-plugins/integration-test/project/dist/'),
+	prefix: '/build-plugins-test-project-artifacts/',
+	decorateReply: false,
+})
+
 fastify.addHook('preHandler', delayMiddleware)
 fastify.addHook('onSend', serverTimingMiddleware)
 fastify.addHook('onSend', noCacheMiddleware)

--- a/packages/integration-tests/src/tests/errors/errors.spec.ts
+++ b/packages/integration-tests/src/tests/errors/errors.spec.ts
@@ -187,7 +187,7 @@ test.describe('errors', () => {
 		)
 		expect(
 			errorSpans3[2].tags['error.source_map_ids'] as string,
-			"this expect must be kept in-sync with the sourceMapId injected into the build-plugins sample project's generated main.js bundle",
-		).toContain('84dc0cdc-a6e0-9bdc-c41e-e6e37df69b73')
+			'this expect must be kept in-sync with the sourceMapId injected into build-plugins/integration-test/project/dist/webpack-config-devtool-source-map-js/main.js',
+		).toContain('ab2a6548-e5d2-9d1a-fa76-1db1692955bc')
 	})
 })

--- a/packages/integration-tests/src/tests/errors/errors.spec.ts
+++ b/packages/integration-tests/src/tests/errors/errors.spec.ts
@@ -175,5 +175,14 @@ test.describe('errors', () => {
 				'9793573cdc2ab308a0b1996bea14253ec8832bc036210475ded0813cafa27066',
 			),
 		).toBeTruthy()
+
+		await recordPage.locator('#button3').click()
+		await recordPage.waitForSpans((spans) => spans.filter((span) => span.name === 'onerror').length === 3)
+		const errorSpans3 = recordPage.receivedSpans.filter((span) => span.name === 'onerror')
+
+		expect(errorSpans3).toHaveLength(3)
+		expect(errorSpans3[2].tags['error.message']).toContain('thisFunctionDoesNotExist')  // browsers report the exact error message differently in this scenario
+		expect((errorSpans3[2].tags['error.source_map_ids'] as string)).toContain('http://localhost:3000/build-plugins-test-project-artifacts/webpack-config-devtool-source-map-js/main.js')
+		expect((errorSpans3[2].tags['error.source_map_ids'] as string), 'this expect must be kept in-sync with the sourceMapId injected into the build-plugins sample project\'s generated main.js bundle').toContain('84dc0cdc-a6e0-9bdc-c41e-e6e37df69b73')
 	})
 })

--- a/packages/integration-tests/src/tests/errors/errors.spec.ts
+++ b/packages/integration-tests/src/tests/errors/errors.spec.ts
@@ -181,8 +181,13 @@ test.describe('errors', () => {
 		const errorSpans3 = recordPage.receivedSpans.filter((span) => span.name === 'onerror')
 
 		expect(errorSpans3).toHaveLength(3)
-		expect(errorSpans3[2].tags['error.message']).toContain('thisFunctionDoesNotExist')  // browsers report the exact error message differently in this scenario
-		expect((errorSpans3[2].tags['error.source_map_ids'] as string)).toContain('http://localhost:3000/build-plugins-test-project-artifacts/webpack-config-devtool-source-map-js/main.js')
-		expect((errorSpans3[2].tags['error.source_map_ids'] as string), 'this expect must be kept in-sync with the sourceMapId injected into the build-plugins sample project\'s generated main.js bundle').toContain('84dc0cdc-a6e0-9bdc-c41e-e6e37df69b73')
+		expect(errorSpans3[2].tags['error.message']).toContain('thisFunctionDoesNotExist') // browsers report the exact error message differently in this scenario
+		expect(errorSpans3[2].tags['error.source_map_ids'] as string).toContain(
+			'http://localhost:3000/build-plugins-test-project-artifacts/webpack-config-devtool-source-map-js/main.js',
+		)
+		expect(
+			errorSpans3[2].tags['error.source_map_ids'] as string,
+			"this expect must be kept in-sync with the sourceMapId injected into the build-plugins sample project's generated main.js bundle",
+		).toContain('84dc0cdc-a6e0-9bdc-c41e-e6e37df69b73')
 	})
 })

--- a/packages/integration-tests/src/tests/errors/views/minified-file-errors.ejs
+++ b/packages/integration-tests/src/tests/errors/views/minified-file-errors.ejs
@@ -9,7 +9,12 @@
     <h1>Minified files with source map ids</h1>
     <button id="button1">Button 1</button>
     <button id="button2">Button 2</button>
+    <button id="button3">Button 3</button>
     <script src="/errors/views/script1.min.js" type="module"></script>
     <script src="/errors/views/script2.min.js"></script>
+    <script src="/build-plugins-test-project-artifacts/webpack-config-devtool-source-map-js/main.js"></script>
+    <script>
+        document.getElementById('button3').addEventListener('click', () => window.globalFunctionThatThrowsError())
+    </script>
 </body>
 </html>


### PR DESCRIPTION
# Description

Created "integration" test within the build-plugins folder for testing behavior with real webpack

Added additional test cases to playwright test to verify that the snippet works properly to get sourceMapId onto the spans


## Type of change
- Chore or internal change (changes not visible to the consumers of the package)

# How has this been tested?
- Added unit tests
- Added integration tests
