### PR TITLE
chore: distinguish beta and prod releases

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,14 +56,20 @@ build:
 build_artifacts:
     stage: build
     only:
-        - /^v[0-9]+\..*/
+        - /^v[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$/
     artifacts:
         paths:
             - artifacts/
     script:
         - if [ ! -d "artifacts" ]; then mkdir artifacts; fi
         - npm run compile
-        - npm pack --pack-destination artifacts --workspace packages/session-recorder --workspace packages/web
+
+        # Check if the tag is a beta version
+        - if [[ "$CI_COMMIT_TAG" =~ -beta\.[0-9]+$ ]]; then
+          npm pack --tag beta --pack-destination artifacts --workspace packages/session-recorder --workspace packages/web;
+          else
+          npm pack --pack-destination artifacts --workspace packages/session-recorder --workspace packages/web;
+          fi
 
         # complete artifacts & checksums
         - cp packages/*/dist/artifacts/* artifacts/
@@ -85,12 +91,21 @@ release_npm:
             - artifacts/
     stage: release
     only:
-        - /^v[0-9]+\..*/
+        - /^v[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$/
     script:
-        # release to NPM
+        # Authenticate to NPM
         - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-        # January: remove --tag beta
-        - for f in artifacts/*.tgz; do npm publish --tag beta ./$f; done;
+
+        # Publish to NPM with conditional tag
+        - for f in artifacts/*.tgz; do
+          if [[ "$CI_COMMIT_TAG" =~ -beta\.[0-9]+$ ]]; then
+          npm publish --tag beta ./$f;
+          else
+          npm publish ./$f;
+          fi;
+          done;
+
+        # Clean up
         - rm -f ~/.npmrc
 
 release_github:
@@ -99,15 +114,20 @@ release_github:
             - artifacts/
     stage: release
     only:
-        - /^v[0-9]+\..*/
+        - /^v[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$/
     script:
+        # Install GitHub CLI
         - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 23F3D4EA75716059
         - echo "deb [arch=$(dpkg --print-architecture)] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
         - sudo apt update
         - sudo apt install gh
 
-        # January: remove --prerelease
-        - gh release create v${CI_COMMIT_REF_NAME:1} ./artifacts/* --prerelease --target $CI_COMMIT_SHA --repo $GITHUB_REPOSITORY
+        # Create GitHub release with conditional prerelease flag
+        - if [[ "$CI_COMMIT_TAG" =~ -beta\.[0-9]+$ ]]; then
+          gh release create v${CI_COMMIT_REF_NAME:1} ./artifacts/* --target $CI_COMMIT_SHA --repo $GITHUB_REPOSITORY --prerelease;
+          else
+          gh release create v${CI_COMMIT_REF_NAME:1} ./artifacts/* --target $CI_COMMIT_SHA --repo $GITHUB_REPOSITORY;
+          fi
 
 release_cdn:
     artifacts:
@@ -115,12 +135,12 @@ release_cdn:
             - artifacts/
     stage: release
     only:
-        - /^v[0-9]+\..*/
+        - /^v[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$/
     needs: ['release_github']
     id_tokens:
         CI_JOB_JWT:
             aud: $CICD_VAULT_ADDR
     script:
-        # authenticate and release to CDN
+        # Authenticate and release to CDN
         - creds-helper init && eval $(creds-helper aws --eval aws:v1/o11y-infra/role/o11y_gdi_otel_js_web_releaser_role)
         - node scripts/release-cdn.mjs v${CI_COMMIT_REF_NAME:1}


### PR DESCRIPTION
# Description

Distinguish between beta and production releases to eliminate the need for manually adding prerelease flags each time.

## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)


# How has this been tested?

Delete options that are not relevant.

- Manual testing
<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
