### PR TITLE
chore(build-plugins): update API and add input validation

### DIFF
--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -21,7 +21,7 @@ runs:
           run: echo "PLAYWRIGHT_CACHE_PATH=$(if [[ $RUNNER_OS == 'macOS' ]]; then echo '~/Library/Caches/ms-playwright'; else echo '~/.cache/ms-playwright'; fi)" >> $GITHUB_ENV
 
         - name: Cache Playwright binaries
-          uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+          uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf
           id: playwright-cache
           with:
               path: ${{ env.PLAYWRIGHT_CACHE_PATH }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5263,16 +5263,16 @@
 			"version": "3.1.2",
 			"license": "MIT"
 		},
-		"node_modules/@splunk/olly-web-build-plugins": {
-			"resolved": "packages/build-plugins",
-			"link": true
-		},
 		"node_modules/@splunk/otel-js-web-integration-tests": {
 			"resolved": "packages/integration-tests",
 			"link": true
 		},
 		"node_modules/@splunk/otel-web": {
 			"resolved": "packages/web",
+			"link": true
+		},
+		"node_modules/@splunk/otel-web-build-plugins": {
+			"resolved": "packages/build-plugins",
 			"link": true
 		},
 		"node_modules/@splunk/otel-web-session-recorder": {
@@ -17313,6 +17313,7 @@
 			}
 		},
 		"packages/build-plugins": {
+			"name": "@splunk/otel-web-build-plugins",
 			"version": "0.20.0-beta.2",
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/packages/build-plugins/README.md
+++ b/packages/build-plugins/README.md
@@ -7,12 +7,12 @@
 ```js
 // webpack.config.js
 
-const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins');
+const { SplunkRumWebpackPlugin } = require('@splunk/olly-web-build-plugins');
 
 module.exports = {
   /* ... */
   plugins: [
-    ollyWebWebpackPlugin({
+    new SplunkRumWebpackPlugin({
       sourceMaps: {
         realm: 'us0',
         token: process.env.SPLUNK_API_TOKEN,

--- a/packages/build-plugins/README.md
+++ b/packages/build-plugins/README.md
@@ -7,7 +7,7 @@
 ```js
 // webpack.config.js
 
-const { SplunkRumWebpackPlugin } = require('@splunk/olly-web-build-plugins');
+const { SplunkRumWebpackPlugin } = require('@splunk/otel-web-build-plugins');
 
 module.exports = {
   /* ... */

--- a/packages/build-plugins/integration-test/integration.test.ts
+++ b/packages/build-plugins/integration-test/integration.test.ts
@@ -39,7 +39,9 @@ describe('webpack sourceMaps plugin', function () {
 		)
 		await verifySourceMapIdInjectionDidNotOccur('./integration-test/project/dist/webpack-config-no-source-maps-js/')
 		await verifySourceMapIdInjectionDidNotOccur('./integration-test/project/dist/webpack-config-devtool-eval-js/')
-		await verifySourceMapIdInjectionDidNotOccur('./integration-test/project/dist/webpack-config-without-source-maps-options-js/')
+		await verifySourceMapIdInjectionDidNotOccur(
+			'./integration-test/project/dist/webpack-config-without-source-maps-options-js/',
+		)
 		await verifySourceMapIdInjectionDidNotOccur('./integration-test/project/dist/webpack-config-without-plugin-js/')
 	})
 })

--- a/packages/build-plugins/integration-test/integration.test.ts
+++ b/packages/build-plugins/integration-test/integration.test.ts
@@ -39,6 +39,7 @@ describe('webpack sourceMaps plugin', function () {
 		)
 		await verifySourceMapIdInjectionDidNotOccur('./integration-test/project/dist/webpack-config-no-source-maps-js/')
 		await verifySourceMapIdInjectionDidNotOccur('./integration-test/project/dist/webpack-config-devtool-eval-js/')
+		await verifySourceMapIdInjectionDidNotOccur('./integration-test/project/dist/webpack-config-without-source-maps-options-js/')
 		await verifySourceMapIdInjectionDidNotOccur('./integration-test/project/dist/webpack-config-without-plugin-js/')
 	})
 })

--- a/packages/build-plugins/integration-test/project/package-lock.json
+++ b/packages/build-plugins/integration-test/project/package-lock.json
@@ -6,13 +6,13 @@
 		"": {
 			"name": "build-plugins-test-project",
 			"devDependencies": {
-				"@splunk/olly-web-build-plugins": "file://../../",
+				"@splunk/otel-web-build-plugins": "file://../../",
 				"webpack": "^5.76.0",
 				"webpack-cli": "^6.0.1"
 			}
 		},
 		"../..": {
-			"name": "@splunk/olly-web-build-plugins",
+			"name": "@splunk/otel-web-build-plugins",
 			"version": "0.20.0-beta.2",
 			"dev": true,
 			"license": "Apache-2.0",
@@ -102,7 +102,7 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
-		"node_modules/@splunk/olly-web-build-plugins": {
+		"node_modules/@splunk/otel-web-build-plugins": {
 			"resolved": "../..",
 			"link": true
 		},

--- a/packages/build-plugins/integration-test/project/package-lock.json
+++ b/packages/build-plugins/integration-test/project/package-lock.json
@@ -24,9 +24,11 @@
 			"devDependencies": {
 				"@types/chai": "^4.3.5",
 				"@types/mocha": "^10.0.1",
+				"@types/sinon": "^17.0.3",
 				"chai": "^4.3.7",
 				"mocha": "^10.2.0",
 				"nyc": "^15.1.0",
+				"sinon": "^15.2.0",
 				"ts-node": "^10.9.1"
 			},
 			"peerDependencies": {

--- a/packages/build-plugins/integration-test/project/package.json
+++ b/packages/build-plugins/integration-test/project/package.json
@@ -9,6 +9,6 @@
 	"devDependencies": {
 		"webpack": "^5.76.0",
 		"webpack-cli": "^6.0.1",
-		"@splunk/olly-web-build-plugins": "file://../../"
+		"@splunk/otel-web-build-plugins": "file://../../"
 	}
 }

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.eval.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.eval.js
@@ -16,7 +16,7 @@
  *
  */
 /* eslint-disable */
-const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
+const { SplunkRumWebpackPlugin } = require('@splunk/olly-web-build-plugins')
 const path = require('path')
 const { getBaseConfig } = require('./webpack-utils')
 
@@ -24,7 +24,7 @@ module.exports = {
 	...getBaseConfig(__filename),
 	devtool: 'eval',
 	plugins: [
-		ollyWebWebpackPlugin({
+		new SplunkRumWebpackPlugin({
 			applicationName: 'sample-app',
 			version: '0.1.0',
 			sourceMaps: {

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.eval.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.eval.js
@@ -25,12 +25,12 @@ module.exports = {
 	devtool: 'eval',
 	plugins: [
 		ollyWebWebpackPlugin({
+			applicationName: 'sample-app',
+			version: '0.1.0',
 			sourceMaps: {
-				applicationName: 'sample-app',
 				disableUpload: true,
 				realm: 'us0',
 				token: '<token>',
-				version: '0.1.0',
 			},
 		}),
 	],

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.eval.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.eval.js
@@ -16,7 +16,7 @@
  *
  */
 /* eslint-disable */
-const { SplunkRumWebpackPlugin } = require('@splunk/olly-web-build-plugins')
+const { SplunkRumWebpackPlugin } = require('@splunk/otel-web-build-plugins')
 const path = require('path')
 const { getBaseConfig } = require('./webpack-utils')
 

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.hidden-source-map.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.hidden-source-map.js
@@ -16,7 +16,7 @@
  *
  */
 /* eslint-disable */
-const { SplunkRumWebpackPlugin } = require('@splunk/olly-web-build-plugins')
+const { SplunkRumWebpackPlugin } = require('@splunk/otel-web-build-plugins')
 const path = require('path')
 const { getBaseConfig } = require('./webpack-utils')
 

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.hidden-source-map.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.hidden-source-map.js
@@ -16,7 +16,7 @@
  *
  */
 /* eslint-disable */
-const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
+const { SplunkRumWebpackPlugin } = require('@splunk/olly-web-build-plugins')
 const path = require('path')
 const { getBaseConfig } = require('./webpack-utils')
 
@@ -24,7 +24,7 @@ module.exports = {
 	...getBaseConfig(__filename),
 	devtool: 'hidden-source-map',
 	plugins: [
-		ollyWebWebpackPlugin({
+		new SplunkRumWebpackPlugin({
 			applicationName: 'sample-app',
 			version: '0.1.0',
 			sourceMaps: {

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.hidden-source-map.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.hidden-source-map.js
@@ -25,12 +25,12 @@ module.exports = {
 	devtool: 'hidden-source-map',
 	plugins: [
 		ollyWebWebpackPlugin({
+			applicationName: 'sample-app',
+			version: '0.1.0',
 			sourceMaps: {
-				applicationName: 'sample-app',
 				disableUpload: true,
 				realm: 'us0',
 				token: '<token>',
-				version: '0.1.0',
 			},
 		}),
 	],

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.source-map.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.source-map.js
@@ -16,7 +16,7 @@
  *
  */
 /* eslint-disable */
-const { SplunkRumWebpackPlugin } = require('@splunk/olly-web-build-plugins')
+const { SplunkRumWebpackPlugin } = require('@splunk/otel-web-build-plugins')
 const path = require('path')
 const { getBaseConfig } = require('./webpack-utils')
 

--- a/packages/build-plugins/integration-test/project/webpack.config.devtool.source-map.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.devtool.source-map.js
@@ -16,7 +16,7 @@
  *
  */
 /* eslint-disable */
-const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
+const { SplunkRumWebpackPlugin } = require('@splunk/olly-web-build-plugins')
 const path = require('path')
 const { getBaseConfig } = require('./webpack-utils')
 
@@ -24,7 +24,7 @@ module.exports = {
 	...getBaseConfig(__filename),
 	devtool: 'source-map',
 	plugins: [
-		ollyWebWebpackPlugin({
+		new SplunkRumWebpackPlugin({
 			applicationName: 'sample-app',
 			version: '0.1.0',
 			sourceMaps: {

--- a/packages/build-plugins/integration-test/project/webpack.config.no-source-maps.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.no-source-maps.js
@@ -24,12 +24,12 @@ module.exports = {
 	...getBaseConfig(__filename),
 	plugins: [
 		ollyWebWebpackPlugin({
+			applicationName: 'sample-app',
+			version: '0.1.0',
 			sourceMaps: {
-				applicationName: 'sample-app',
 				disableUpload: true,
 				realm: 'us0',
 				token: '<token>',
-				version: '0.1.0',
 			},
 		}),
 	],

--- a/packages/build-plugins/integration-test/project/webpack.config.no-source-maps.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.no-source-maps.js
@@ -16,7 +16,7 @@
  *
  */
 /* eslint-disable */
-const { SplunkRumWebpackPlugin } = require('@splunk/olly-web-build-plugins')
+const { SplunkRumWebpackPlugin } = require('@splunk/otel-web-build-plugins')
 const path = require('path')
 const { getBaseConfig } = require('./webpack-utils')
 

--- a/packages/build-plugins/integration-test/project/webpack.config.no-source-maps.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.no-source-maps.js
@@ -16,14 +16,14 @@
  *
  */
 /* eslint-disable */
-const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
+const { SplunkRumWebpackPlugin } = require('@splunk/olly-web-build-plugins')
 const path = require('path')
 const { getBaseConfig } = require('./webpack-utils')
 
 module.exports = {
 	...getBaseConfig(__filename),
 	plugins: [
-		ollyWebWebpackPlugin({
+		new SplunkRumWebpackPlugin({
 			applicationName: 'sample-app',
 			version: '0.1.0',
 			sourceMaps: {

--- a/packages/build-plugins/integration-test/project/webpack.config.without-source-maps-options.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.without-source-maps-options.js
@@ -22,16 +22,10 @@ const { getBaseConfig } = require('./webpack-utils')
 
 module.exports = {
 	...getBaseConfig(__filename),
-	devtool: 'source-map',
 	plugins: [
 		ollyWebWebpackPlugin({
 			applicationName: 'sample-app',
 			version: '0.1.0',
-			sourceMaps: {
-				disableUpload: true,
-				realm: 'us0',
-				token: '<token>',
-			},
 		}),
 	],
 }

--- a/packages/build-plugins/integration-test/project/webpack.config.without-source-maps-options.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.without-source-maps-options.js
@@ -16,14 +16,14 @@
  *
  */
 /* eslint-disable */
-const { ollyWebWebpackPlugin } = require('@splunk/olly-web-build-plugins')
+const { SplunkRumWebpackPlugin } = require('@splunk/olly-web-build-plugins')
 const path = require('path')
 const { getBaseConfig } = require('./webpack-utils')
 
 module.exports = {
 	...getBaseConfig(__filename),
 	plugins: [
-		ollyWebWebpackPlugin({
+		new SplunkRumWebpackPlugin({
 			applicationName: 'sample-app',
 			version: '0.1.0',
 		}),

--- a/packages/build-plugins/integration-test/project/webpack.config.without-source-maps-options.js
+++ b/packages/build-plugins/integration-test/project/webpack.config.without-source-maps-options.js
@@ -16,7 +16,7 @@
  *
  */
 /* eslint-disable */
-const { SplunkRumWebpackPlugin } = require('@splunk/olly-web-build-plugins')
+const { SplunkRumWebpackPlugin } = require('@splunk/otel-web-build-plugins')
 const path = require('path')
 const { getBaseConfig } = require('./webpack-utils')
 

--- a/packages/build-plugins/package-lock.json
+++ b/packages/build-plugins/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "@splunk/olly-web-build-plugins",
+	"name": "@splunk/otel-web-build-plugins",
 	"version": "0.20.0-beta.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@splunk/olly-web-build-plugins",
+			"name": "@splunk/otel-web-build-plugins",
 			"version": "0.20.0-beta.2",
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/packages/build-plugins/package.json
+++ b/packages/build-plugins/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@splunk/olly-web-build-plugins",
+	"name": "@splunk/otel-web-build-plugins",
 	"private": true,
 	"version": "0.20.0-beta.2",
 	"description": "Build plugins for users of @splunk/otel-web",

--- a/packages/build-plugins/src/index.ts
+++ b/packages/build-plugins/src/index.ts
@@ -17,11 +17,11 @@
  */
 import { createUnplugin, UnpluginFactory } from 'unplugin'
 
-import type { WebpackPluginInstance } from 'webpack'
+import type { Compiler, WebpackPluginInstance } from 'webpack'
 import { PLUGIN_NAME } from './utils'
 import { applySourceMapsInject, applySourceMapsUpload } from './webpack'
 
-export interface OllyWebPluginOptions {
+export interface SplunkRumPluginOptions {
 	/** Optional. If provided, this should match the "applicationName" used where SplunkRum.init() is called. */
 	applicationName?: string
 
@@ -41,7 +41,7 @@ export interface OllyWebPluginOptions {
 	}
 }
 
-const unpluginFactory: UnpluginFactory<OllyWebPluginOptions | undefined> = (options) => ({
+const unpluginFactory: UnpluginFactory<SplunkRumPluginOptions | undefined> = (options) => ({
 	name: PLUGIN_NAME,
 	webpack(compiler) {
 		const logger = compiler.getInfrastructureLogger(PLUGIN_NAME)
@@ -71,4 +71,15 @@ const unpluginFactory: UnpluginFactory<OllyWebPluginOptions | undefined> = (opti
 
 const unplugin = createUnplugin(unpluginFactory)
 
-export const ollyWebWebpackPlugin: (options: OllyWebPluginOptions) => WebpackPluginInstance = unplugin.webpack
+export class SplunkRumWebpackPlugin {
+	// unplugin gives us a function.  Wrap it in a class to follow the convention of webpack plugins, which generally use classes
+	private unpluginInstance: ReturnType<typeof unplugin.webpack>;
+
+	constructor(options: SplunkRumPluginOptions) {
+		this.unpluginInstance = unplugin.webpack(options);
+	}
+
+	apply(compiler: Compiler): void {
+		this.unpluginInstance.apply(compiler);
+	}
+}

--- a/packages/build-plugins/src/index.ts
+++ b/packages/build-plugins/src/index.ts
@@ -22,11 +22,14 @@ import { PLUGIN_NAME } from './utils'
 import { applySourceMapsInject, applySourceMapsUpload } from './webpack'
 
 export interface OllyWebPluginOptions {
+	/** Optional. If provided, this should match the "applicationName" used where SplunkRum.init() is called. */
+	applicationName?: string
+
+	/** Optional. If provided, this should match the "version" used where SplunkRum.init() is called. */
+	version?: string
+
 	/** Plugin configuration for source map ID injection and source map file uploads */
 	sourceMaps?: {
-		/** Optional. If provided, this should match the "applicationName" used where SplunkRum.init() is called. */
-		applicationName?: string
-
 		/** Optional. If true, the plugin will inject source map IDs into the final JavaScript bundles, but it will not upload any source map files. */
 		disableUpload?: boolean
 
@@ -35,9 +38,6 @@ export interface OllyWebPluginOptions {
 
 		/** API token used to authenticate the file upload requests.  This is not the same as the rumAccessToken used in SplunkRum.init(). */
 		token: string
-
-		/** Optional. If provided, this should match the "version" used where SplunkRum.init() is called. */
-		version?: string
 	}
 }
 

--- a/packages/build-plugins/src/index.ts
+++ b/packages/build-plugins/src/index.ts
@@ -25,9 +25,6 @@ export interface SplunkRumPluginOptions {
 	/** Optional. If provided, this should match the "applicationName" used where SplunkRum.init() is called. */
 	applicationName?: string
 
-	/** Optional. If provided, this should match the "version" used where SplunkRum.init() is called. */
-	version?: string
-
 	/** Plugin configuration for source map ID injection and source map file uploads */
 	sourceMaps?: {
 		/** Optional. If true, the plugin will inject source map IDs into the final JavaScript bundles, but it will not upload any source map files. */
@@ -39,6 +36,9 @@ export interface SplunkRumPluginOptions {
 		/** API token used to authenticate the file upload requests.  This is not the same as the rumAccessToken used in SplunkRum.init(). */
 		token: string
 	}
+
+	/** Optional. If provided, this should match the "version" used where SplunkRum.init() is called. */
+	version?: string
 }
 
 const unpluginFactory: UnpluginFactory<SplunkRumPluginOptions | undefined> = (options) => ({
@@ -49,37 +49,39 @@ const unpluginFactory: UnpluginFactory<SplunkRumPluginOptions | undefined> = (op
 		if (options.sourceMaps) {
 			applySourceMapsInject(compiler)
 
-			let shouldApplySourceMapsUpload = true;
+			let shouldApplySourceMapsUpload = true
 			if (options.sourceMaps.disableUpload) {
 				logger.debug('sourceMaps.disableUpload is set — skipping source map uploads')
-				shouldApplySourceMapsUpload = false;
+				shouldApplySourceMapsUpload = false
 			} else if (!options.sourceMaps.realm) {
 				logger.warn('sourceMaps.realm is missing — skipping source map uploads')
-				shouldApplySourceMapsUpload = false;
+				shouldApplySourceMapsUpload = false
 			} else if (!options.sourceMaps.token) {
 				logger.warn('sourceMaps.token is missing — skipping source map uploads')
-				shouldApplySourceMapsUpload = false;
+				shouldApplySourceMapsUpload = false
 			}
 
 			if (shouldApplySourceMapsUpload) {
 				applySourceMapsUpload(compiler, options)
 			}
 		}
-
 	},
 })
 
 const unplugin = createUnplugin(unpluginFactory)
 
 export class SplunkRumWebpackPlugin {
-	// unplugin gives us a function.  Wrap it in a class to follow the convention of webpack plugins, which generally use classes
-	private unpluginInstance: ReturnType<typeof unplugin.webpack>;
+	// unplugin.webpack gives us a function
+	// Wrap it in this exported class so that usages of our plugin follow the convention of other webpack plugins,
+	// which use the "new" keyword to create instances of plugins
+
+	private unpluginInstance: WebpackPluginInstance
 
 	constructor(options: SplunkRumPluginOptions) {
-		this.unpluginInstance = unplugin.webpack(options);
+		this.unpluginInstance = unplugin.webpack(options)
 	}
 
 	apply(compiler: Compiler): void {
-		this.unpluginInstance.apply(compiler);
+		this.unpluginInstance.apply(compiler)
 	}
 }

--- a/packages/build-plugins/src/webpack/index.ts
+++ b/packages/build-plugins/src/webpack/index.ts
@@ -29,7 +29,7 @@ import { join } from 'path'
 import { uploadFile } from '../httpUtils'
 import { AxiosError } from 'axios'
 import type { Compiler } from 'webpack'
-import { OllyWebPluginOptions } from '../index'
+import { SplunkRumPluginOptions } from '../index'
 
 /**
  * The part of the webpack plugin responsible for injecting the sourceMapId code snippet into the JS bundles.
@@ -97,7 +97,7 @@ export function applySourceMapsInject(compiler: Compiler) {
 /**
  * The part of the webpack plugin responsible for uploading source maps from the output directory.
  */
-export function applySourceMapsUpload(compiler: Compiler, options: OllyWebPluginOptions): void {
+export function applySourceMapsUpload(compiler: Compiler, options: SplunkRumPluginOptions): void {
 	const logger = compiler.getInfrastructureLogger(PLUGIN_NAME)
 
 	compiler.hooks.afterEmit.tapAsync(PLUGIN_NAME, async (compilation, callback) => {

--- a/packages/build-plugins/src/webpack/index.ts
+++ b/packages/build-plugins/src/webpack/index.ts
@@ -128,8 +128,8 @@ export function applySourceMapsUpload(compiler: Compiler, options: OllyWebPlugin
 		}
 		const parameters = Object.fromEntries(
 			[
-				['appName', options.sourceMaps.applicationName],
-				['appVersion', options.sourceMaps.version],
+				['appName', options.applicationName],
+				['appVersion', options.version],
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			].filter(([_, value]) => typeof value !== 'undefined'),
 		)


### PR DESCRIPTION
# Description

 * Add input validation check before applying source map upload plugin
 * change exported function `o11yWebWebpackPlugin` to exported class `SplunkRumWebpackPlugin`
 * change package name to `otel-web-build-plugins`
 * move general `applicationName` and `version` options to the top-level of the plugin config

_List Github issue(s) which this PR fixes._

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Chore or internal change (changes not visible to the consumers of the package)
- Documentation update

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added integration tests

