### PR TITLE
chore: run unit tests in WebKit and Firefox

### DIFF
--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -37,6 +37,6 @@ runs:
               npx playwright install webkit
 
         - name: Install Playwright OS dependencies
-          if: steps.playwright-cache.outputs.cache-hit != 'true'
+          if: steps.playwright-cache.outputs.cache-hit == 'true'
           shell: bash
           run: npx playwright install-deps

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
     linkChecker:
+        name: Link Checker
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
 permissions: read-all
 
 jobs:
-    unit-tests:
+    build:
+        name: Build
         runs-on: ubuntu-latest
         permissions: read-all
         steps:
@@ -33,12 +34,7 @@ jobs:
             - name: Transpile code
               run: npm run compile
 
-            - name: Install playwright
-              uses: ./.github/actions/install-playwright
-
-            - name: Unit tests
-              run: npm run test:unit
-
-    playwright:
+    tests:
+        name: Tests
         uses: ./.github/workflows/tests.yml
         secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,16 +1,16 @@
-name: Playwright tests
+name: Unit & Integration Tests
 on:
     workflow_call:
 
 jobs:
-    playwright:
+    tests-linux:
+        name: Unit & Integration Tests - ${{ matrix.browser }}
         timeout-minutes: 60
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
                 browser: [chromium, firefox, chrome, edge]
-        name: Playwright Tests - ${{ matrix.browser }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4.2.2
@@ -37,13 +37,29 @@ jobs:
                   path: packages/integration-tests/blob-report
                   retention-days: 1
 
-    playwright-macos:
+            - name: Run Unit Tests
+              if: ${{ matrix.browser != 'edge' && matrix.browser != 'chrome' }}
+              # Firefox tests are flaky.
+              # Remove once this issue is resolved: https://github.com/vitest-dev/vitest/issues/7377
+              continue-on-error: ${{ matrix.browser == 'firefox' }}
+              run: npm run test:unit -- --browser.name=${{ matrix.browser }}
+
+            - name: Upload test:unit report
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
+              if: ${{ !cancelled() && matrix.browser != 'edge' && matrix.browser != 'chrome' }}
+              with:
+                  name: vitest-report-${{ matrix.browser }}-attempt-${{ github.run_attempt }}
+                  path: vitest-report/
+                  retention-days: 14
+
+    tests-macos:
         timeout-minutes: 60
         runs-on: macos-latest
         strategy:
             fail-fast: false
             matrix:
                 browser: [webkit]
+        name: Unit & Integration Tests - ${{ matrix.browser }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4.2.2
@@ -70,9 +86,13 @@ jobs:
                   path: packages/integration-tests/blob-report
                   retention-days: 1
 
+            - name: Run Unit Tests
+              run: npm run test:unit -- --browser.name=${{ matrix.browser }}
+
     merge-reports:
+        name: Merge playwright reports
         if: ${{ !cancelled() }}
-        needs: [playwright, playwright-macos]
+        needs: [tests-linux, tests-macos]
 
         runs-on: ubuntu-latest
         steps:
@@ -104,13 +124,14 @@ jobs:
                   retention-days: 14
 
     check-failure:
-        needs: [playwright, playwright-macos, merge-reports]
+        name: Check if all tests passed
+        needs: [tests-linux, tests-macos, merge-reports]
         runs-on: ubuntu-latest
         if: ${{ always() }}
         steps:
             - name: Check if any playwright tests failed
               run: |
-                  if [ "${{ needs.playwright.result }}" != "success" ] || [ "${{ needs['playwright-macos'].result }}" != "success" ];  then
+                  if [ "${{ needs['tests-linux'].result }}" != "success" ] || [ "${{ needs['tests-macos'].result }}" != "success" ];  then
                   echo "One or more tests failed."
                   exit 1
                   else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,6 +89,14 @@ jobs:
             - name: Run Unit Tests
               run: npm run test:unit -- --browser.name=${{ matrix.browser }}
 
+            - name: Upload test:unit report
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
+              if: ${{ !cancelled() }}
+              with:
+                  name: vitest-report-${{ matrix.browser }}-attempt-${{ github.run_attempt }}
+                  path: vitest-report/
+                  retention-days: 14
+
     merge-reports:
         name: Merge playwright reports
         if: ${{ !cancelled() }}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -8,7 +8,7 @@
 		"pretty": true,
 		"resolveJsonModule": true,
 		"target": "ES2017",
-		"types": ["vitest/global"],
+		"types": ["vitest/global", "@vitest/browser/providers/playwright"],
 		"noEmit": true,
 		"allowJs": true
 	},

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -29,12 +29,19 @@ export default defineConfig({
 				{
 					browser: 'chromium',
 				},
+				{
+					browser: 'firefox',
+				},
+				{
+					browser: 'webkit',
+				},
 			],
 			api: {
 				host: '127.0.0.1',
 				port: 1234,
 			},
 		},
+		retry: 3,
 		clearMocks: true,
 		coverage: {
 			exclude: ['**/node_modules'],


### PR DESCRIPTION
# Description

The new version of Vitest allows us to run our unit tests in Firefox and WebKit in addition to Chromium. This PR updates the configuration and CI pipeline to enable tests across all three browsers.

## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)


# How has this been tested?

Delete options that are not relevant.

- Manual testing

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
