### PR TITLE
fix: typo of disabledByAutomationFrameworkDetection

### DIFF
--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -306,7 +306,7 @@ export const SplunkRum: SplunkOtelWebType = {
 		}
 
 		if (options.disableAutomationFrameworks && navigator.webdriver) {
-			this.disableAutomationFrameworks = true
+			this.disabledByAutomationFrameworkDetection = true
 			diag.error('SplunkRum will not be initialized, automation frameworks are not allowed.')
 			return
 		}


### PR DESCRIPTION
# Description

Fix typo that causes different info being logged. Functionality stays the same

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
