### PR TITLE
fix: null-prototype objects missing toString method

### DIFF
--- a/packages/web/src/SplunkErrorInstrumentation.ts
+++ b/packages/web/src/SplunkErrorInstrumentation.ts
@@ -38,7 +38,17 @@ function stringifyValue(value: unknown) {
 		return '(undefined)'
 	}
 
-	return value.toString()
+	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#null-prototype_objects
+	// Check for null-prototype objects
+	if (value.toString) {
+		return value.toString()
+	}
+
+	try {
+		return Object.prototype.toString.call(value)
+	} catch {
+		return '(unknown)'
+	}
 }
 
 function parseErrorStack(stack: string): string {


### PR DESCRIPTION
# Description

Fixes toString being called on null-prototype objects

[_List Github issue(s) which this PR fixes._](https://github.com/signalfx/splunk-otel-js-web/issues/1041)

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Tests to be added