### PR TITLE
fix: unload event and data sending

### DIFF
--- a/packages/session-recorder/src/BatchLogProcessor.ts
+++ b/packages/session-recorder/src/BatchLogProcessor.ts
@@ -40,8 +40,12 @@ export class BatchLogProcessor {
 		this.scheduledDelayMillis = config?.scheduledDelayMillis || 5000
 		this.exporter = exporter
 
-		window.addEventListener('unload', () => {
-			this._flushAll()
+		// Use visibility event instead of unload event
+		// https://developer.chrome.com/docs/web-platform/deprecating-unload
+		window.addEventListener('visibilitychange', () => {
+			if (document.visibilityState === 'hidden') {
+				this._flushAll()
+			}
 		})
 	}
 

--- a/packages/session-recorder/src/OTLPLogExporter.ts
+++ b/packages/session-recorder/src/OTLPLogExporter.ts
@@ -128,10 +128,15 @@ export default class OTLPLogExporter {
 
 		const compressed = gzipSync(strToU8(JSON.stringify(logsData)))
 
+		// There is a limit for fetchAlive param of 64kB, use it only when under limit and page is 'hidden' - which could
+		// be when page is unloading
+		const sentDataUsingBeaconLikeRequest = compressed.byteLength < 65536 && document.visibilityState === 'hidden'
+
 		fetch(this.config.beaconUrl, {
 			method: 'POST',
 			body: compressed,
 			headers: headers,
+			keepalive: sentDataUsingBeaconLikeRequest,
 		}).catch(() => {
 			// TODO remove this once we have ingest with correct cors headers
 		})


### PR DESCRIPTION
# Description

Remove deprecated 'unload' event.
Add keepAlive param for data to be sent more reliably.

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Delete options that are not relevant.

- Manual testing