### PR TITLE
fix: missing SplunkOtelWebConfig and SplunkOtelWebExporterOptions types

### DIFF
--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -79,7 +79,7 @@ export { SplunkZipkinExporter } from './exporters/zipkin'
 export * from './SplunkWebTracerProvider'
 export * from './SessionBasedSampler'
 
-export { SplunkOtelWebConfig, SplunkOtelWebExporterOptions }
+export type { SplunkOtelWebConfig, SplunkOtelWebExporterOptions }
 
 interface SplunkOtelWebConfigInternal extends SplunkOtelWebConfig {
 	bufferSize?: number

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -79,6 +79,8 @@ export { SplunkZipkinExporter } from './exporters/zipkin'
 export * from './SplunkWebTracerProvider'
 export * from './SessionBasedSampler'
 
+export { SplunkOtelWebConfig, SplunkOtelWebExporterOptions }
+
 interface SplunkOtelWebConfigInternal extends SplunkOtelWebConfig {
 	bufferSize?: number
 	bufferTimeout?: number


### PR DESCRIPTION
# Description

Missing SplunkOtelWebConfig and SplunkOtelWebExporterOptions types
Fixes https://github.com/signalfx/splunk-otel-js-web/issues/1076

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
