### PR TITLE
fix: access to undefined navigator

### DIFF
--- a/packages/web/src/storage/cookie-store.ts
+++ b/packages/web/src/storage/cookie-store.ts
@@ -20,7 +20,7 @@ import { isIframe } from '../utils'
 import { throttle } from '../utils/throttle'
 import { Store } from './store'
 
-const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+const isSafari = /^((?!chrome|android).)*safari/i.test(globalThis.navigator?.userAgent) // navigator is defined in node since v21
 
 export class CookieStore<T> implements Store<T> {
 	private cachedValue: T | undefined


### PR DESCRIPTION
# Description

Node versions before v21 does not contain `navigator`. Then the code throws `ReferenceError` during execution.

_List Github issue(s) which this PR fixes._

https://splunk.atlassian.net/browse/SWAT-9205

## Type of change

- Bug fix (non-breaking change which fixes an issue)


