### PR TITLE
fix: calling sendBeacon in IE11

### DIFF
--- a/packages/web/src/exporters/common.ts
+++ b/packages/web/src/exporters/common.ts
@@ -41,7 +41,10 @@ export function NATIVE_XHR_SENDER(url: string, data: string, headers?: Record<st
 	})
 	xhr.send(data)
 }
-export function NATIVE_BEACON_SENDER(url: string, data: string, blobPropertyBag?: BlobPropertyBag): void {
-	const payload = blobPropertyBag ? new Blob([data], blobPropertyBag) : data
-	navigator.sendBeacon(url, payload)
-}
+export const NATIVE_BEACON_SENDER: SplunkExporterConfig['beaconSender'] =
+	typeof navigator !== 'undefined' && navigator.sendBeacon
+		? (url: string, data: string, blobPropertyBag?: BlobPropertyBag) => {
+				const payload = blobPropertyBag ? new Blob([data], blobPropertyBag) : data
+				navigator.sendBeacon(url, payload)
+			}
+		: undefined

--- a/packages/web/src/exporters/otlp.ts
+++ b/packages/web/src/exporters/otlp.ts
@@ -27,8 +27,7 @@ import {
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base'
 
 export class SplunkOTLPTraceExporter extends OTLPTraceExporter {
-	protected readonly _beaconSender: SplunkExporterConfig['beaconSender'] =
-		typeof navigator !== 'undefined' && navigator.sendBeacon ? NATIVE_BEACON_SENDER : undefined
+	protected readonly _beaconSender: SplunkExporterConfig['beaconSender'] = NATIVE_BEACON_SENDER
 
 	protected readonly _onAttributesSerializing: SplunkExporterConfig['onAttributesSerializing']
 


### PR DESCRIPTION
# Description

The file `packages/web/src/exporters/zipkin.ts` does not contain a sendBeacon check. In IE11, sendBeacon is not defined, so it throws an error.

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

