### PR TITLE
feat: respect `ignoreUrls` option for `routeChange` span creation

### DIFF
--- a/packages/integration-tests/src/tests/user-interaction/history-ignore.ejs
+++ b/packages/integration-tests/src/tests/user-interaction/history-ignore.ejs
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>History events test</title>
+    <%- renderAgent({}, true) %>
+    <script>
+		window.SplunkRumOptions.ignoreUrls = [/another/, window.location.href]
+		window.SplunkRum && window.SplunkRum.init(window.SplunkRumOptions)
+    </script>
+
+</head>
+<body>
+<h1>History events test</h1>
+
+<button type="button" id="btnGoToPage">Go to another page</button>
+<button type="button" id="btnGoToPage2">Go to another page 2</button>
+<button type="button" id="btnGoBack">Go back</button>
+<button type="button" id="btnGoForward">Go forward</button>
+<pre id="scenarioDisplay"></pre>
+<script id="scenario">
+	document.querySelector('#btnGoToPage').addEventListener('click', function () {
+		location.hash = 'another-page';
+	});
+	document.querySelector('#btnGoBack').addEventListener('click', function () {
+		history.back();
+	});
+	document.querySelector('#btnGoForward').addEventListener('click', function () {
+		history.forward();
+	});
+	document.querySelector('#btnGoToPage2').addEventListener('click', function () {
+        history.pushState(null, null, 'page-2');
+    })
+
+
+</script>
+<script>scenarioDisplay.innerHTML = scenario.innerHTML;</script>
+</body>
+</html>

--- a/packages/integration-tests/src/tests/user-interaction/history-ignore.spec.ts
+++ b/packages/integration-tests/src/tests/user-interaction/history-ignore.spec.ts
@@ -1,0 +1,41 @@
+/**
+ *
+ * Copyright 2020-2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { test } from '../../utils/test'
+import { expect } from '@playwright/test'
+
+test.describe('history', () => {
+	test('ignoreUrls option is respected', async ({ recordPage }) => {
+		await recordPage.goTo('/user-interaction/history-ignore.ejs')
+
+		await recordPage.locator('#btnGoToPage').click()
+		await recordPage.locator('#btnGoBack').click()
+		await recordPage.locator('#btnGoForward').click()
+		await recordPage.locator('#btnGoToPage2').click()
+
+		await recordPage.waitForSpans((spans) => spans.filter((span) => span.name === 'routeChange').length === 1)
+		const navigationSpans = recordPage.receivedSpans.filter((span) => span.name === 'routeChange')
+
+		expect(navigationSpans).toHaveLength(1)
+		expect(navigationSpans[0].tags['component']).toBe('user-interaction')
+		expect(navigationSpans[0].tags['prev.href']).toBe(
+			'http://localhost:3000/user-interaction/history-ignore.ejs#another-page',
+		)
+		expect(navigationSpans[0].tags['location.href']).toBe('http://localhost:3000/user-interaction/page-2')
+		expect(recordPage.receivedErrorSpans).toHaveLength(0)
+	})
+})

--- a/packages/integration-tests/src/tests/user-interaction/history.ejs
+++ b/packages/integration-tests/src/tests/user-interaction/history.ejs
@@ -4,14 +4,14 @@
 	<meta charset="UTF-8">
 	<title>History events test</title>
   <%- renderAgent() %>
-  
+
 </head>
 <body>
   <h1>History events test</h1>
 
   <button type="button" id="btnGoToPage">Go to another page</button>
   <button type="button" id="btnGoBack">Go back</button>
-  <button type="button" id="btnGoForward">Go back</button>
+  <button type="button" id="btnGoForward">Go forward</button>
 
   <pre id="scenarioDisplay"></pre>
   <script id="scenario">

--- a/packages/web/src/upstream/user-interaction/instrumentation.ts
+++ b/packages/web/src/upstream/user-interaction/instrumentation.ts
@@ -37,7 +37,9 @@ function defaultShouldPreventSpanCreation() {
  * If zone.js is available then it patches the zone otherwise it patches
  * addEventListener of Element
  */
-export class UserInteractionInstrumentation extends InstrumentationBase<unknown> {
+export class UserInteractionInstrumentation<
+	T extends UserInteractionInstrumentationConfig,
+> extends InstrumentationBase<T> {
 	readonly moduleName: string = 'user-interaction'
 
 	readonly version = VERSION
@@ -59,7 +61,7 @@ export class UserInteractionInstrumentation extends InstrumentationBase<unknown>
 
 	private _zonePatched?: boolean
 
-	constructor(config?: UserInteractionInstrumentationConfig) {
+	constructor(config?: T) {
 		super('@opentelemetry/instrumentation-user-interaction', VERSION, config)
 		this._eventNames = new Set(config?.eventNames ?? DEFAULT_EVENT_NAMES)
 		this._shouldPreventSpanCreation =


### PR DESCRIPTION
# Description

Ensure that `routeChange` spans are not created for URLs matching the `ignoreUrls` pattern.

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How has this been tested?

Delete options that are not relevant.

- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
