### PR TITLE
fix: do not start new session when recorder type is not present

### DIFF
--- a/packages/web/src/session/session.ts
+++ b/packages/web/src/session/session.ts
@@ -151,6 +151,9 @@ export function updateSessionStatus({
 	if (recorderType && sessionState.rt !== recorderType) {
 		sessionState.rt = recorderType
 		shouldForceWrite = true
+
+		store?.set(sessionState, cookieDomain)
+		store?.flush()
 	}
 
 	eventTarget?.emit('session-changed', { sessionId: sessionState.id })
@@ -268,8 +271,13 @@ export function getIsNewSession(): boolean {
 
 export function checkSessionRecorderType(recorderType: RecorderType): void {
 	const sessionState = getCurrentSessionState({ forceDiskRead: true })
-	if (sessionState && sessionState.rt !== recorderType) {
-		updateSessionStatus({ forceStore: true, forceNewSession: true, recorderType })
-		console.debug('Session recorder type changed, creating new session', { recorderType })
+	if (sessionState) {
+		if (sessionState.rt === undefined) {
+			updateSessionStatus({ forceStore: true, recorderType })
+			console.debug('Session recorder type initialized', { recorderType })
+		} else if (sessionState.rt !== recorderType) {
+			updateSessionStatus({ forceStore: true, forceNewSession: true, recorderType })
+			console.debug('Session recorder type changed, creating new session', { recorderType })
+		}
 	}
 }


### PR DESCRIPTION
# Description

When a new session is started  - typically the first time they visit the website—we initialize the agent without setting a recorderType. Later, when the replay is initialized, we incorrectly force a new session. This is not the correct behavior.

Instead, in this scenario, we should only update the cookie state, not start a completely new session.

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Delete options that are not relevant.

- Manual testing


<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
