### PR TITLE
fix: improve error msg for failed resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ blob-report/
 playwright/.cache/
 
 .turbo
+
+coverage

--- a/packages/integration-tests/src/tests/errors/errors.spec.ts
+++ b/packages/integration-tests/src/tests/errors/errors.spec.ts
@@ -37,6 +37,8 @@ test.describe('errors', () => {
 			(errorSpans[0].tags['target_src'] as string).endsWith('/nonexistent.png'),
 			`Checking target_src: ${errorSpans[0]['target_src']}`,
 		).toBeTruthy()
+
+		expect(errorSpans[0].tags['error.message']).toBe('Failed to load <img src="/nonexistent.png" />')
 	})
 
 	test('JS syntax error', async ({ recordPage, browserName }) => {

--- a/packages/web/src/SplunkErrorInstrumentation.ts
+++ b/packages/web/src/SplunkErrorInstrumentation.ts
@@ -85,7 +85,7 @@ function parseErrorStack(stack: string): string {
 
 function addStackIfUseful(span: Span, err: Error) {
 	if (err && err.stack && useful(err.stack)) {
-		//g et sourcemap ids and add to span as error.source_map_ids
+		// get sourcemap ids and add to span as error.source_map_ids
 		span.setAttribute('error.stack', limitLen(err.stack.toString(), STACK_LIMIT))
 		const sourcemapIds = parseErrorStack(err.stack)
 		if (sourcemapIds) {

--- a/packages/web/src/types/type-guards/node.ts
+++ b/packages/web/src/types/type-guards/node.ts
@@ -15,6 +15,6 @@
  * limitations under the License.
  *
  */
-export * from './error'
-export * from './string'
-export * from './node'
+
+export const isElement = (maybeElement: EventTarget | Node): maybeElement is Element =>
+	(<Node>maybeElement)?.nodeType === Node.ELEMENT_NODE


### PR DESCRIPTION
# Description

Closes https://github.com/signalfx/splunk-otel-js-web/issues/1276

When the browser fails to load an element — such as an image, video, or script — it triggers an empty event with no message. According to the documentation, this empty error means the resource either failed to load or couldn’t be used. 

New message is introduced saying - `Failed to load <tag_name src="src_attribute_value" />`


https://developer.mozilla.org/en-US/docs/Web/API/Window/error_event
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Delete options that are not relevant.

- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
