### PR TITLE
chore(session-recorder): remove 429 from retry logic

### DIFF
--- a/packages/session-recorder/src/api/api-fetch.ts
+++ b/packages/session-recorder/src/api/api-fetch.ts
@@ -48,7 +48,7 @@ const defaultHeaders = {
 
 const abortControllersByUrl = new Map<string, AbortController>()
 
-const ERROR_CODES_TO_RETRY = new Set([408, 429, 500, 502, 503, 504])
+const ERROR_CODES_TO_RETRY = new Set([408, 500, 502, 503, 504])
 
 const MAX_HTTP_ERROR_RETRIES = 3
 

--- a/packages/session-recorder/src/api/index.ts
+++ b/packages/session-recorder/src/api/index.ts
@@ -1,0 +1,19 @@
+/**
+ *
+ * Copyright 2020-2025 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+export * from './api-error'
+export * from './api-fetch'

--- a/packages/session-recorder/src/otlp-log-exporter.ts
+++ b/packages/session-recorder/src/otlp-log-exporter.ts
@@ -22,7 +22,7 @@ import { gzipSync, strToU8 } from 'fflate'
 import { nanoid } from 'nanoid'
 import type { JsonArray, JsonObject, JsonValue } from 'type-fest'
 
-import { apiFetch, ApiParams } from './api/api-fetch'
+import { ApiError, apiFetch, ApiParams } from './api'
 import {
 	addLogToQueue,
 	getQueuedLogs,
@@ -235,6 +235,17 @@ export default class OTLPLogExporter {
 			removeQueuedLog(queuedLog)
 		}
 
+		const onFetchError = (error: unknown) => {
+			if (!queuedLog) {
+				return
+			}
+
+			if (error instanceof ApiError && error.status === 429) {
+				log.debug('Removing queued log', { ...queuedLog, data: '[truncated]' })
+				removeQueuedLog(queuedLog)
+			}
+		}
+
 		if (document.visibilityState === 'hidden') {
 			const compressedData = gzipSync(uint8ArrayData)
 
@@ -245,11 +256,12 @@ export default class OTLPLogExporter {
 				endpoint,
 				{ body: compressedData, headers, keepalive: shouldUseKeepAliveOption },
 				onFetchSuccess,
+				onFetchError,
 			)
 		} else {
 			compressAsync(uint8ArrayData)
 				.then((compressedData) => {
-					void sendByFetch(endpoint, { body: compressedData, headers }, onFetchSuccess)
+					void sendByFetch(endpoint, { body: compressedData, headers }, onFetchSuccess, onFetchError)
 				})
 				.catch((error) => {
 					log.error('Could not compress data', error)
@@ -262,6 +274,7 @@ const sendByFetchInternal = async (
 	endpoint: string,
 	fetchParams: Pick<ApiParams, 'headers' | 'keepalive' | 'body'>,
 	onSuccess: () => void,
+	onError: (error: unknown) => void,
 ) => {
 	try {
 		await apiFetch(endpoint, {
@@ -278,6 +291,7 @@ const sendByFetchInternal = async (
 		onSuccess()
 	} catch (error) {
 		log.error('Could not sent data to BE - fetch', error)
+		onError(error)
 	}
 }
 


### PR DESCRIPTION
# Description

- Don't retry rate-limited requests (429 errors)
- Clean up queued logs when rate limits hit

## Type of change

Delete options that are not relevant.


- Chore or internal change (changes not visible to the consumers of the package)


# How has this been tested?

Delete options that are not relevant.

- Manual testing


<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
