### PR TITLE
fix(session-recorder): missing types for session recorder init options

### DIFF
--- a/packages/session-recorder/package.json
+++ b/packages/session-recorder/package.json
@@ -54,6 +54,7 @@
 		"@splunk/otel-web": "workspace:*",
 		"@swc/core": "^1.13.5",
 		"@swc/helpers": "^0.5.17",
+		"copy-webpack-plugin": "^13.0.1",
 		"fork-ts-checker-webpack-plugin": "^9.1.0",
 		"npm-run-all": "^4.1.5",
 		"protobufjs-cli": "^1.1.3",

--- a/packages/session-recorder/src/session-replay/cdn-module-types.d.ts
+++ b/packages/session-recorder/src/session-replay/cdn-module-types.d.ts
@@ -73,8 +73,7 @@ declare module 'https://cdn.signalfx.com/o11y-gdi-rum/session-replay/v2.5.1/sess
 
 	type LogLevel = 'debug' | 'info' | 'warn' | 'error'
 
-	export const SensitivityRuleTypesArray = ['mask', 'unmask', 'exclude'] as const
-	export type SensitivityRuleType = (typeof SensitivityRuleTypesArray)[number]
+	export type SensitivityRuleType = 'mask' | 'unmask' | 'exclude'
 
 	export interface SensitivityRule {
 		rule: SensitivityRuleType

--- a/packages/session-recorder/src/session-replay/cdn-module.ts
+++ b/packages/session-recorder/src/session-replay/cdn-module.ts
@@ -16,6 +16,7 @@
  *
  */
 
+/// <reference types="./cdn-module-types.d.ts" preserve="true"  />
 export {
 	type ConfigFeatures,
 	type PackAssetsConfig,

--- a/packages/session-recorder/tsconfig.base.json
+++ b/packages/session-recorder/tsconfig.base.json
@@ -10,7 +10,6 @@
 		"pretty": true,
 		"resolveJsonModule": true,
 		"target": "ES2017",
-		"types": ["./src/session-replay/cdn-module.d.ts"],
 		"skipLibCheck": true,
 		"strict": true
 	},

--- a/packages/session-recorder/webpack.config.js
+++ b/packages/session-recorder/webpack.config.js
@@ -17,6 +17,7 @@
  */
 const path = require('node:path')
 
+const CopyWebpackPlugin = require('copy-webpack-plugin')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
 
@@ -146,6 +147,16 @@ const cjsConfig = (env, argv) => {
 			},
 			path: path.resolve(__dirname, './dist/cjs'),
 		},
+		plugins: [
+			new CopyWebpackPlugin({
+				patterns: [
+					{
+						from: 'src/session-replay/cdn-module-types.d.ts',
+						to: 'session-replay/cdn-module-types.d.ts',
+					},
+				],
+			}),
+		],
 	}
 }
 
@@ -180,6 +191,16 @@ const esmConfig = (env, argv) => {
 			},
 			path: path.resolve(__dirname, './dist/esm'),
 		},
+		plugins: [
+			new CopyWebpackPlugin({
+				patterns: [
+					{
+						from: 'src/session-replay/cdn-module-types.d.ts',
+						to: 'session-replay/cdn-module-types.d.ts',
+					},
+				],
+			}),
+		],
 	}
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
       '@swc/helpers':
         specifier: ^0.5.17
         version: 0.5.17
+      copy-webpack-plugin:
+        specifier: ^13.0.1
+        version: 13.0.1(webpack@5.102.0)
       fork-ts-checker-webpack-plugin:
         specifier: ^9.1.0
         version: 9.1.0(typescript@5.9.3)(webpack@5.102.0)
@@ -3076,6 +3079,12 @@ packages:
   cookie@1.0.2:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
     engines: {node: '>=18'}
+
+  copy-webpack-plugin@13.0.1:
+    resolution: {integrity: sha512-J+YV3WfhY6W/Xf9h+J1znYuqTye2xkBUIGyTPWuBAT27qajBa5mR4f8WBmfDY3YjRftT2kqZZiLi1qf0H+UOFw==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      webpack: ^5.1.0
 
   core-js-compat@3.45.1:
     resolution: {integrity: sha512-tqTt5T4PzsMIZ430XGviK4vzYSoeNJ6CXODi6c/voxOT6IZqBht5/EKaSNnYiEjjRYxjVz7DQIsOsY0XNi8PIA==}
@@ -9346,6 +9355,15 @@ snapshots:
 
   cookie@1.0.2: {}
 
+  copy-webpack-plugin@13.0.1(webpack@5.102.0):
+    dependencies:
+      glob-parent: 6.0.2
+      normalize-path: 3.0.0
+      schema-utils: 4.3.2
+      serialize-javascript: 6.0.2
+      tinyglobby: 0.2.14
+      webpack: 5.102.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack-cli@6.0.1)
+
   core-js-compat@3.45.1:
     dependencies:
       browserslist: 4.26.2
@@ -9984,10 +10002,6 @@ snapshots:
   faye-websocket@0.11.4:
     dependencies:
       websocket-driver: 0.7.4
-
-  fdir@6.4.6(picomatch@4.0.2):
-    optionalDependencies:
-      picomatch: 4.0.2
 
   fdir@6.4.6(picomatch@4.0.3):
     optionalDependencies:
@@ -12445,8 +12459,8 @@ snapshots:
   vite@7.0.0(@types/node@24.7.0)(jiti@2.6.1)(terser@5.43.1)(tsx@4.20.6):
     dependencies:
       esbuild: 0.25.10
-      fdir: 6.4.6(picomatch@4.0.2)
-      picomatch: 4.0.2
+      fdir: 6.4.6(picomatch@4.0.3)
+      picomatch: 4.0.3
       postcss: 8.5.6
       rollup: 4.44.0
       tinyglobby: 0.2.14


### PR DESCRIPTION
# Description

This PR adds TypeScript and IntelliSense support for the SplunkSessionRecorder initialization options when the library is used by customers. Previously, it only included partial type definitions — for example, features and other options were resolved to any because the declaration file for this part was missing.

<img width="1111" height="343" alt="image" src="https://github.com/user-attachments/assets/0c0963dc-2193-4378-8f08-95161e979a87" />


## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Delete options that are not relevant.

- Manual testing


<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
