### PR TITLE
chore(deps): override vulnerable protobufjs versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
 	"packageManager": "pnpm@10.26.1",
 	"pnpm": {
 		"overrides": {
-			"@opentelemetry/api": "$@opentelemetry/api"
+			"@opentelemetry/api": "$@opentelemetry/api",
+			"protobufjs@>=7.0.0 <7.6.5": "7.6.5"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,7 @@ catalogs:
 
 overrides:
   '@opentelemetry/api': 1.9.0
+  protobufjs@>=7.0.0 <7.6.5: 7.6.5
 
 importers:
 
@@ -6781,8 +6782,8 @@ packages:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
 
-  protobufjs@7.6.2:
-    resolution: {integrity: sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   protobufjs@8.5.0:
@@ -9652,7 +9653,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.6.2
+      protobufjs: 7.6.5
       yargs: 17.7.2
 
   '@hapi/address@5.1.1':
@@ -10720,7 +10721,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.52.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.25.1(@opentelemetry/api@1.9.0)
-      protobufjs: 7.6.2
+      protobufjs: 7.6.5
 
   '@opentelemetry/propagator-aws-xray@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -15839,7 +15840,7 @@ snapshots:
       err-code: 2.0.3
       retry: 0.12.0
 
-  protobufjs@7.6.2:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
## Summary
- add one scoped pnpm override covering vulnerable protobufjs 7.x releases below 7.6.5
- resolve the affected paths from protobufjs 7.6.2 to patched 7.6.5
- keep the parent OpenTelemetry and gRPC packages unchanged
- leave the separate protobufjs 8.5.0 path unchanged

## Security
- CVE-2026-54269 / GHSA-f38q-mgvj-vph7 — Medium — schema-derived names can shadow runtime-significant properties; first patched in 7.6.3
- CVE-2026-59877 / GHSA-j3f2-48v5-ccww — Medium — denial of service via an infinite loop in .proto option parsing; patched in 7.6.5

Using 7.6.5 fixes both findings affecting the locked 7.6.2 paths.

## Remediation commands
- `pnpm audit --fix` identified two overlapping vulnerable ranges
- consolidated those ranges into one protobufjs 7.x-only override pinned to same-major 7.6.5: `protobufjs@>=7.0.0 <7.6.5`
- `pnpm install --lockfile-only --config.fixLockfile=false`

Pnpm audit suggested unbounded replacement ranges that resolved 7.x to 8.x during validation. This PR pins 7.6.5 to avoid an unintended major upgrade.

## Verification
- `pnpm install --lockfile-only --frozen-lockfile`
- `pnpm --filter @splunk/otel-web build`
- `pnpm --filter @splunk/otel-web exec vitest run tests/splunk-exporter.test.ts` — 27 passed across Chromium, Firefox, and WebKit
- `git diff --check`
