### PR TITLE
chore(deps): override vulnerable picomatch versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
 	"packageManager": "pnpm@10.26.1",
 	"pnpm": {
 		"overrides": {
-			"@opentelemetry/api": "$@opentelemetry/api"
+			"@opentelemetry/api": "$@opentelemetry/api",
+			"picomatch@>=4.0.0 <4.0.4": "4.0.4"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,7 @@ catalogs:
 
 overrides:
   '@opentelemetry/api': 1.9.0
+  picomatch@>=4.0.0 <4.0.4: 4.0.4
 
 importers:
 
@@ -6598,10 +6599,6 @@ packages:
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -15668,8 +15665,6 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   picomatch@4.0.5: {}
@@ -17076,7 +17071,7 @@ snapshots:
   unplugin@3.0.0:
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):


### PR DESCRIPTION
## Summary
- add a scoped pnpm override for vulnerable picomatch 4.x releases
- resolve unplugin 3.0.0 from picomatch 4.0.3 to patched 4.0.4
- retain unplugin 3.0.0 and its existing compatible dependency declaration

## Security
- CVE-2026-33671 / GHSA-c2c7-rcm5-vvqj — High — ReDoS via extglob quantifiers
- CVE-2026-33672 / GHSA-3v7f-55p6-f55p — Medium — method injection in POSIX character classes

Both advisories affect picomatch >=4.0.0 <4.0.4 and are fixed in 4.0.4.

## Remediation commands
- `pnpm audit --fix` identified the vulnerable-range override
- retained only the picomatch override and pinned its replacement to same-major 4.0.4
- `pnpm install --lockfile-only --config.fixLockfile=false`

## Verification
- `pnpm install --lockfile-only --frozen-lockfile`
- `pnpm --filter @splunk/rum-build-plugins build`
- `git diff --check`